### PR TITLE
Change to YAML syntax definition

### DIFF
--- a/C++11.tmLanguage
+++ b/C++11.tmLanguage
@@ -224,7 +224,7 @@
 			<key>begin</key>
 			<string>(?x)
                 ^\s*\#\s*(define)\s+             # define
-                ((?&lt;id&gt;[a-zA-Z_]\w*))  # macro name
+                ((?&lt;id&gt;[a-zA-Z_]\w*))            # macro name
                 (?:                              # and optionally:
                     (\()                         # an open parenthesis
                         (

--- a/C++11.tmLanguage
+++ b/C++11.tmLanguage
@@ -45,7 +45,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>R"([a-zA-Z_]\w*)?\(</string>
+			<string>R\"([a-zA-Z_]\w*)?\(</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -55,7 +55,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>\)\1?"</string>
+			<string>\)\1?\"</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>
@@ -119,8 +119,12 @@
 			<string>storage.modifier.c++</string>
 		</dict>
 		<dict>
-			<key>comment</key>
-			<string>common C constant naming idiom -- kConstantVariable</string>
+			<key>match</key>
+			<string>\b(nullptr|NULL|true|false)\b</string>
+			<key>name</key>
+			<string>constant.language.c++}</string>
+		</dict>
+		<dict>
 			<key>match</key>
 			<string>\bk[A-Z]\w*\b</string>
 			<key>name</key>
@@ -140,9 +144,99 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(nullptr|NULL|true|false)\b</string>
+			<string>\b(u_char|u_short|u_int|u_long|ushort|uint|u_quad_t|quad_t|qaddr_t|caddr_t|daddr_t|dev_t|fixpt_t|blkcnt_t|blksize_t|gid_t|in_addr_t|in_port_t|ino_t|key_t|mode_t|nlink_t|id_t|pid_t|off_t|segsz_t|swblk_t|uid_t|id_t|clock_t|size_t|ssize_t|time_t|useconds_t|suseconds_t)\b</string>
 			<key>name</key>
-			<string>constant.language.c++</string>
+			<string>support.type.sys-types.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t)\b</string>
+			<key>name</key>
+			<string>support.type.pthread.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|int_least8_t|int_least16_t|int_least32_t|int_least64_t|uint_least8_t|uint_least16_t|uint_least32_t|uint_least64_t|int_fast8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t|intptr_t|uintptr_t|intmax_t|intmax_t|uintmax_t|uintmax_t)\b</string>
+			<key>name</key>
+			<string>support.type.stdint.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(noErr|kNilOptions|kInvalidID|kVariableLengthArray)\b</string>
+			<key>name</key>
+			<string>support.constant.mac-classic.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(AbsoluteTime|Boolean|Byte|ByteCount|ByteOffset|BytePtr|CompTimeValue|ConstLogicalAddress|ConstStrFileNameParam|ConstStringPtr|Duration|Fixed|FixedPtr|Float32|Float32Point|Float64|Float80|Float96|FourCharCode|Fract|FractPtr|Handle|ItemCount|LogicalAddress|OptionBits|OSErr|OSStatus|OSType|OSTypePtr|PhysicalAddress|ProcessSerialNumber|ProcessSerialNumberPtr|ProcHandle|Ptr|ResType|ResTypePtr|ShortFixed|ShortFixedPtr|SignedByte|SInt16|SInt32|SInt64|SInt8|Size|StrFileName|StringHandle|StringPtr|TimeBase|TimeRecord|TimeScale|TimeValue|TimeValue64|UInt16|UInt32|UInt64|UInt8|UniChar|UniCharCount|UniCharCountPtr|UniCharPtr|UnicodeScalarValue|UniversalProcHandle|UniversalProcPtr|UnsignedFixed|UnsignedFixedPtr|UnsignedWide|UTF16Char|UTF32Char|UTF8Char)\b</string>
+			<key>name</key>
+			<string>support.type.mac-classic.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(friend|explicit|virtual)\b</string>
+			<key>name</key>
+			<string>storage.modifier.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(private:|protected:|public:)</string>
+			<key>name</key>
+			<string>storage.modifier.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(catch|operator|try|throw|using)\b</string>
+			<key>name</key>
+			<string>keyword.control.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\bdelete\b(\s*\[\])?|\bnew\b(?!])</string>
+			<key>name</key>
+			<string>keyword.control.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(f|m)[A-Z]\w*\b</string>
+			<key>name</key>
+			<string>variable.other.readwrite.member.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(this)\b</string>
+			<key>name</key>
+			<string>variable.language.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\btemplate(&lt;[\s\w,&lt;&gt;]*&gt;)?</string>
+			<key>name</key>
+			<string>storage.type.template.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(const_cast|dynamic_cast|reinterpret_cast|static_cast)\b\s*</string>
+			<key>name</key>
+			<string>keyword.operator.cast.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(?:and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq)\b</string>
+			<key>name</key>
+			<string>keyword.operator.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(class|wchar_t)\b</string>
+			<key>name</key>
+			<string>storage.type.c++</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>\b(export|mutable|typename)\b</string>
+			<key>name</key>
+			<string>storage.modifier.c++</string>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -152,7 +246,7 @@
 			<key>match</key>
 			<string>\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b</string>
 			<key>name</key>
-			<string>constant.numeric.c++</string>
+			<string>constant.numeric.c++}</string>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -414,52 +508,22 @@
 			</array>
 		</dict>
 		<dict>
-			<key>match</key>
-			<string>\b(u_char|u_short|u_int|u_long|ushort|uint|u_quad_t|quad_t|qaddr_t|caddr_t|daddr_t|dev_t|fixpt_t|blkcnt_t|blksize_t|gid_t|in_addr_t|in_port_t|ino_t|key_t|mode_t|nlink_t|id_t|pid_t|off_t|segsz_t|swblk_t|uid_t|id_t|clock_t|size_t|ssize_t|time_t|useconds_t|suseconds_t)\b</string>
-			<key>name</key>
-			<string>support.type.sys-types.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\b(pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t)\b</string>
-			<key>name</key>
-			<string>support.type.pthread.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\b(int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|int_least8_t|int_least16_t|int_least32_t|int_least64_t|uint_least8_t|uint_least16_t|uint_least32_t|uint_least64_t|int_fast8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t|intptr_t|uintptr_t|intmax_t|intmax_t|uintmax_t|uintmax_t)\b</string>
-			<key>name</key>
-			<string>support.type.stdint.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\b(noErr|kNilOptions|kInvalidID|kVariableLengthArray)\b</string>
-			<key>name</key>
-			<string>support.constant.mac-classic.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\b(AbsoluteTime|Boolean|Byte|ByteCount|ByteOffset|BytePtr|CompTimeValue|ConstLogicalAddress|ConstStrFileNameParam|ConstStringPtr|Duration|Fixed|FixedPtr|Float32|Float32Point|Float64|Float80|Float96|FourCharCode|Fract|FractPtr|Handle|ItemCount|LogicalAddress|OptionBits|OSErr|OSStatus|OSType|OSTypePtr|PhysicalAddress|ProcessSerialNumber|ProcessSerialNumberPtr|ProcHandle|Ptr|ResType|ResTypePtr|ShortFixed|ShortFixedPtr|SignedByte|SInt16|SInt32|SInt64|SInt8|Size|StrFileName|StringHandle|StringPtr|TimeBase|TimeRecord|TimeScale|TimeValue|TimeValue64|UInt16|UInt32|UInt64|UInt8|UniChar|UniCharCount|UniCharCountPtr|UniCharPtr|UnicodeScalarValue|UniversalProcHandle|UniversalProcPtr|UnsignedFixed|UnsignedFixedPtr|UnsignedWide|UTF16Char|UTF32Char|UTF8Char)\b</string>
-			<key>name</key>
-			<string>support.type.mac-classic.c++</string>
-		</dict>
-		<dict>
 			<key>include</key>
 			<string>#block</string>
 		</dict>
 		<dict>
 			<key>begin</key>
 			<string>(?x)
-            (?:  ^                                 # begin-of-line
+            (?:  ^                                                        # begin-of-line
               |
                  (?: (?= \s )           (?&lt;!else|new|return) (?&lt;=\w)      #  or word + space before name
-                   | (?= \s*[A-Za-z_] ) (?&lt;!&amp;&amp;)       (?&lt;=[*&amp;&gt;])   #  or type modifier before name
+                   | (?= \s*[A-Za-z_] ) (?&lt;!&amp;&amp;)       (?&lt;=[*&amp;&gt;])          #  or type modifier before name
                  )
             )
             (\s*) (?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate|sizeof|alignof)\s*\()
             (
-                (?: [~A-Za-z_]\w*+ | :: | &lt;(\w+,?\s*)++&gt; )++ |                  # actual name
-                (?: (?&lt;=operator) (?: [-*&amp;&lt;&gt;=+!]+ | \(\) | \[\] ) )  # if it is a C++ operator
+                (?: [A-Za-z_]\w*+ | :: | &lt;(\w+,?\s*)++&gt; )++ |            # actual name
+                (?: (?&lt;=operator) (?: [-*&amp;&lt;&gt;=+!]+ | \(\) | \[\] ) )       # if it is a C++ operator
             )
              \s*(?=\()</string>
 			<key>beginCaptures</key>
@@ -507,83 +571,13 @@
 			</array>
 		</dict>
 		<dict>
-			<key>match</key>
-			<string>\b(friend|explicit|virtual)\b</string>
-			<key>name</key>
-			<string>storage.modifier.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\b(private:|protected:|public:)</string>
-			<key>name</key>
-			<string>storage.modifier.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\b(catch|operator|try|throw|using)\b</string>
-			<key>name</key>
-			<string>keyword.control.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\bdelete\b(\s*\[\])?|\bnew\b(?!])</string>
-			<key>name</key>
-			<string>keyword.control.c++</string>
-		</dict>
-		<dict>
-			<key>comment</key>
-			<string>common C++ instance var naming idiom -- fMemberName</string>
-			<key>match</key>
-			<string>\b(f|m)[A-Z]\w*\b</string>
-			<key>name</key>
-			<string>variable.other.readwrite.member.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\b(this)\b</string>
-			<key>name</key>
-			<string>variable.language.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\btemplate(&lt;[\s\w,&lt;&gt;]*&gt;)?</string>
-			<key>name</key>
-			<string>storage.type.template.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\b(const_cast|dynamic_cast|reinterpret_cast|static_cast)\b\s*</string>
-			<key>name</key>
-			<string>keyword.operator.cast.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?x)(
-                \b(?:and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq)\b
-            )</string>
-			<key>name</key>
-			<string>keyword.operator.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\b(class|wchar_t)\b</string>
-			<key>name</key>
-			<string>storage.type.c++</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>\b(export|mutable|typename)\b</string>
-			<key>name</key>
-			<string>storage.modifier.c++</string>
-		</dict>
-		<dict>
 			<key>begin</key>
 			<string>(?x)
-                    (?:  ^                                 # begin-of-line
-                      |  (?: (?&lt;!else|new|=) )             #  or word + space before name
-                    )
-                    ((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
-                     \s*(\()                           # start bracket or end-of-line
+      (?:  ^                                 # begin-of-line
+        |  (?: (?&lt;!else|new|=) )             #  or word + space before name
+      )
+      ((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
+       \s*(\()                           # start bracket or end-of-line
 </string>
 			<key>beginCaptures</key>
 			<dict>

--- a/C++11.tmLanguage
+++ b/C++11.tmLanguage
@@ -546,7 +546,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\btemplate(&lt;[\s\w,]*&gt;)?</string>
+			<string>\btemplate(&lt;[\s\w,&lt;&gt;]*&gt;)?</string>
 			<key>name</key>
 			<string>storage.type.template.c++</string>
 		</dict>

--- a/C++11.tmLanguage
+++ b/C++11.tmLanguage
@@ -24,9 +24,9 @@
 	<string>-\*- C\+\+ -\*-</string>
 	<key>foldingStartMarker</key>
 	<string>(?x)
-		 /\*\*(?!\*)
-		|^(?![^{]*?//|[^{]*?/\*(?!.*?\*/.*?\{)).*?\{\s*($|//|/\*(?!.*?\*/.*\S))
-	</string>
+         /\*\*(?!\*)
+        |^(?![^{]*?//|[^{]*?/\*(?!.*?\*/.*?\{)).*?\{\s*($|//|/\*(?!.*?\*/.*\S))
+</string>
 	<key>foldingStopMarker</key>
 	<string>(?&lt;!\*)\*\*/|^\s*\}</string>
 	<key>keyEquivalent</key>
@@ -223,18 +223,18 @@
 		<dict>
 			<key>begin</key>
 			<string>(?x)
-				^\s*\#\s*(define)\s+             # define
-				((?&lt;id&gt;[a-zA-Z_]\w*))  # macro name
-				(?:                              # and optionally:
-					(\()                         # an open parenthesis
-						(
-							\s* \g&lt;id&gt; \s*       # first argument
-							((,) \s* \g&lt;id&gt; \s*)*  # additional arguments
-							(?:\.\.\.)?          # varargs ellipsis?
-						)
-					(\))                         # a close parenthesis
-				)?
-			</string>
+                ^\s*\#\s*(define)\s+             # define
+                ((?&lt;id&gt;[a-zA-Z_]\w*))  # macro name
+                (?:                              # and optionally:
+                    (\()                         # an open parenthesis
+                        (
+                            \s* \g&lt;id&gt; \s*       # first argument
+                            ((,) \s* \g&lt;id&gt; \s*)*  # additional arguments
+                            (?:\.\.\.)?          # varargs ellipsis?
+                        )
+                    (\))                         # a close parenthesis
+                )?
+</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -450,18 +450,18 @@
 		<dict>
 			<key>begin</key>
 			<string>(?x)
-			(?:  ^                                 # begin-of-line
-			  |
-				 (?: (?= \s )           (?&lt;!else|new|return) (?&lt;=\w)      #  or word + space before name
-				   | (?= \s*[A-Za-z_] ) (?&lt;!&amp;&amp;)       (?&lt;=[*&amp;&gt;])   #  or type modifier before name
-				 )
-			)
-			(\s*) (?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate|sizeof|alignof)\s*\()
-			(
-				(?: [~A-Za-z_]\w*+ | :: | &lt;(\w+,?\s*)++&gt; )++ |                  # actual name
-				(?: (?&lt;=operator) (?: [-*&amp;&lt;&gt;=+!]+ | \(\) | \[\] ) )  # if it is a C++ operator
-			)
-			 \s*(?=\()</string>
+            (?:  ^                                 # begin-of-line
+              |
+                 (?: (?= \s )           (?&lt;!else|new|return) (?&lt;=\w)      #  or word + space before name
+                   | (?= \s*[A-Za-z_] ) (?&lt;!&amp;&amp;)       (?&lt;=[*&amp;&gt;])   #  or type modifier before name
+                 )
+            )
+            (\s*) (?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate|sizeof|alignof)\s*\()
+            (
+                (?: [~A-Za-z_]\w*+ | :: | &lt;(\w+,?\s*)++&gt; )++ |                  # actual name
+                (?: (?&lt;=operator) (?: [-*&amp;&lt;&gt;=+!]+ | \(\) | \[\] ) )  # if it is a C++ operator
+            )
+             \s*(?=\()</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -559,12 +559,8 @@
 		<dict>
 			<key>match</key>
 			<string>(?x)(
-				\b(?:and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq)\b
-			)</string>
-			<!-- 				#| [+\-]{2}
-				#| ([+\-/%^~&amp;*&gt;&lt;!](=|\s+)
-				#| \b[\|&amp;]{1,2}\b
-				#| \s+[&gt;&lt;]{2}\s+) -->
+                \b(?:and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq)\b
+            )</string>
 			<key>name</key>
 			<string>keyword.operator.c++</string>
 		</dict>
@@ -583,12 +579,12 @@
 		<dict>
 			<key>begin</key>
 			<string>(?x)
-					(?:  ^                                 # begin-of-line
-					  |  (?: (?&lt;!else|new|=) )             #  or word + space before name
-					)
-					((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
-					 \s*(\()                           # start bracket or end-of-line
-				</string>
+                    (?:  ^                                 # begin-of-line
+                      |  (?: (?&lt;!else|new|=) )             #  or word + space before name
+                    )
+                    ((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
+                     \s*(\()                           # start bracket or end-of-line
+</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -625,12 +621,12 @@
 		<dict>
 			<key>begin</key>
 			<string>(?x)
-					(?:  ^                                 # begin-of-line
-					  |  (?: (?&lt;!else|new|=) )             #  or word + space before name
-					)
-					((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
-					 \s*(\()                           # terminating semi-colon
-				</string>
+                    (?:  ^                                 # begin-of-line
+                      |  (?: (?&lt;!else|new|=) )             #  or word + space before name
+                    )
+                    ((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
+                     \s*(\()                           # terminating semi-colon
+</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -670,7 +666,7 @@
 		<key>access</key>
 		<dict>
 			<key>match</key>
-			<string>\.[a-zA-Z_]\w*\b(?!\s*\()|\->[a-zA-Z_]\w*\b(?!\s*\()</string>
+			<string>\.[a-zA-Z_]\w*\b(?!\s*\()|\-&gt;[a-zA-Z_]\w*\b(?!\s*\()</string>
 			<key>name</key>
 			<string>variable.other.dot-access.c++</string>
 		</dict>
@@ -772,10 +768,10 @@
 					</dict>
 					<key>match</key>
 					<string>(?x) (?: (?= \s )  (?:(?&lt;=else|new|return) | (?&lt;!\w)) (\s+))?
-			(\b
-				(?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate|sizeof|alignof)\s*\()(?:(?!NS)[A-Za-z_]\w*+\b | :: )++                  # actual name
-			)
-			 \s*(\()</string>
+            (\b
+                (?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate|sizeof|alignof)\s*\()(?:(?!NS)[A-Za-z_]\w*+\b | :: )++                  # actual name
+            )
+             \s*(\()</string>
 					<key>name</key>
 					<string>meta.function-call.c++</string>
 				</dict>
@@ -795,16 +791,16 @@
 					</dict>
 					<key>match</key>
 					<string>(?x)
-					(?x)
-			(?:
-				 (?: (?= \s )           (?&lt;!else|new|return) (?&lt;=\w)\s+      #  or word + space before name
-				 )
-			)
-			(
-				(?: [A-Za-z_]\w*+ | :: )++    |              # actual name
-				(?: (?&lt;=operator) (?: [-*&amp;&lt;&gt;=+!]+ | \(\) | \[\] ) )?  # if it is a C++ operator
-			)
-			 \s*(\()</string>
+                    (?x)
+            (?:
+                 (?: (?= \s )           (?&lt;!else|new|return) (?&lt;=\w)\s+      #  or word + space before name
+                 )
+            )
+            (
+                (?: [A-Za-z_]\w*+ | :: )++    |              # actual name
+                (?: (?&lt;=operator) (?: [-*&amp;&lt;&gt;=+!]+ | \(\) | \[\] ) )?  # if it is a C++ operator
+            )
+             \s*(\()</string>
 					<key>name</key>
 					<string>meta.initialization.c++</string>
 				</dict>
@@ -899,6 +895,79 @@
 				</dict>
 			</array>
 		</dict>
+		<key>constructor</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(?x)
+                    (?:  ^\s*)                             # begin-of-line
+                    ((?!while|for|do|if|else|switch|catch|enumerate|r?iterate|sizeof|alignof)[A-Za-z_][A-Za-z0-9_:]*) # actual name
+                     \s*(\()                            # start bracket or end-of-line
+</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.c++</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.parameters.c++</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.parameters.c++</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.function.constructor.c++</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$base</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(?x)
+                    (:)                            # begin-of-line
+                    ((?=\s*[A-Za-z_][A-Za-z0-9_:]* # actual name
+                     \s*(\()))                      # start bracket or end-of-line
+</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.parameters.c++</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?=\{)</string>
+					<key>name</key>
+					<string>meta.function.constructor.initializer-list.c++</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$base</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
 		<key>disabled</key>
 		<dict>
 			<key>begin</key>
@@ -918,6 +987,13 @@
 					<string>#pragma-mark</string>
 				</dict>
 			</array>
+		</dict>
+		<key>operator</key>
+		<dict>
+			<key>match</key>
+			<string>\b(sizeof|alignof)\b</string>
+			<key>name</key>
+			<string>keyword.operator.function.c++</string>
 		</dict>
 		<key>parens</key>
 		<dict>
@@ -1306,130 +1382,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>operator</key>
-		<dict>
-			<key>match</key>
-			<string>\b(sizeof|alignof)\b</string>
-			<key>name</key>
-			<string>keyword.operator.function.c++</string>
-		</dict>
-		<key>string_escaped_char</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})</string>
-					<key>name</key>
-					<string>constant.character.escape.c++</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\\.</string>
-					<key>name</key>
-					<string>invalid.illegal.unknown-escape.c++</string>
-				</dict>
-			</array>
-		</dict>
-		<key>string_placeholder</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>(?x)%
-							(\d+\$)?                             # field (argument #)
-							[#0\- +']*                           # flags
-							[,;:_]?                              # separator character (AltiVec)
-							((-?\d+)|\*(-?\d+\$)?)?              # minimum field width
-							(\.((-?\d+)|\*(-?\d+\$)?)?)?         # precision
-							(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier
-							[diouxXDOUeEfFgGaACcSspn%]           # conversion type
-						</string>
-					<key>name</key>
-					<string>constant.other.placeholder.c++</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>%</string>
-					<key>name</key>
-					<string>invalid.illegal.placeholder.c++</string>
-				</dict>
-			</array>
-		</dict>
-		<key>constructor</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>(?x)
-					(?:  ^\s*)                             # begin-of-line
-					((?!while|for|do|if|else|switch|catch|enumerate|r?iterate|sizeof|alignof)[A-Za-z_][A-Za-z0-9_:]*) # actual name
-					 \s*(\()                            # start bracket or end-of-line
-				</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.function.c++</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.parameters.c++</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>\)</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.parameters.c++</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>meta.function.constructor.c++</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>$base</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>(?x)
-					(:)                            # begin-of-line
-					((?=\s*[A-Za-z_][A-Za-z0-9_:]* # actual name
-					 \s*(\()))                      # start bracket or end-of-line
-				</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.parameters.c++</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(?=\{)</string>
-					<key>name</key>
-					<string>meta.function.constructor.initializer-list.c++</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>$base</string>
-						</dict>
-					</array>
-				</dict>
-			</array>
-		</dict>
 		<key>special_block</key>
 		<dict>
 			<key>patterns</key>
@@ -1566,6 +1518,50 @@
 							<string>$base</string>
 						</dict>
 					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>string_escaped_char</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})</string>
+					<key>name</key>
+					<string>constant.character.escape.c++</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>invalid.illegal.unknown-escape.c++</string>
+				</dict>
+			</array>
+		</dict>
+		<key>string_placeholder</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(?x)%
+                            (\d+\$)?                             # field (argument #)
+                            [#0\- +']*                           # flags
+                            [,;:_]?                              # separator character (AltiVec)
+                            ((-?\d+)|\*(-?\d+\$)?)?              # minimum field width
+                            (\.((-?\d+)|\*(-?\d+\$)?)?)?         # precision
+                            (hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier
+                            [diouxXDOUeEfFgGaACcSspn%]           # conversion type
+</string>
+					<key>name</key>
+					<string>constant.other.placeholder.c++</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>%</string>
+					<key>name</key>
+					<string>invalid.illegal.placeholder.c++</string>
 				</dict>
 			</array>
 		</dict>

--- a/C++11.tmLanguage
+++ b/C++11.tmLanguage
@@ -1571,7 +1571,7 @@
 		</dict>
 	</dict>
 	<key>scopeName</key>
-	<string>source.c++11</string>
+	<string>source.c++</string>
 	<key>uuid</key>
 	<string>26251B18-6B1D-11D9-AFDB-000D93589AF6</string>
 </dict>

--- a/C++11.tmLanguage.YAML
+++ b/C++11.tmLanguage.YAML
@@ -1,63 +1,143 @@
 comment: Incomplete C++11 tmLanguage
 fileTypes: [cpp, cc, tcc, cp, cxx, c++, hh, thh, hpp, hxx, h++, inl, ipp]
 firstLineMatch: -\*- C\+\+ -\*-
-foldingStartMarker: |
+foldingStartMarker: !!regex |
     (?x)
              /\*\*(?!\*)
             |^(?![^{]*?//|[^{]*?/\*(?!.*?\*/.*?\{)).*?\{\s*($|//|/\*(?!.*?\*/.*\S))
-foldingStopMarker: (?<!\*)\*\*/|^\s*\}
+foldingStopMarker: !!regex (?<!\*)\*\*/|^\s*\}
 keyEquivalent: ^~C
 name: C++11
+
 patterns:
-- {include: '#special_block'}
-- {include: '#block'}
--   begin: R"([a-zA-Z_]\w*)?\(
-    beginCaptures:
-        '0': {name: punctuation.definition.string.begin.raw.c++}
-    end: \)\1?"
-    endCaptures:
-        '0': {name: punctuation.definition.string.end.raw.c++}
-    name: string.quoted.raw.c++
-    patterns:
-    - {include: '#string_escaped_char'}
-    - {include: '#string_placeholder'}
-- {match: \b(constexpr|auto)\b, name: storage.modifier.c++}
+- include: '#special_block'
+- include: '#block'
+
+     ########     ###     ######  ####  ######
+     ##     ##   ## ##   ##    ##  ##  ##    ##
+     ##     ##  ##   ##  ##        ##  ##
+     ########  ##     ##  ######   ##  ##
+     ##     ## #########       ##  ##  ##
+     ##     ## ##     ## ##    ##  ##  ##    ##
+     ########  ##     ##  ######  ####  ######
+
+  # raw string literal
+- begin: !!regex R\"([a-zA-Z_]\w*)?\(
+  beginCaptures:
+      '0': {name: punctuation.definition.string.begin.raw.c++}
+  end: !!regex \)\1?\"
+  endCaptures:
+      '0': {name: punctuation.definition.string.end.raw.c++}
+  name: string.quoted.raw.c++
+  patterns:
+  - {include: '#string_escaped_char'}
+  - {include: '#string_placeholder'}
+
+- {match: !!regex \b(constexpr|auto)\b, name: storage.modifier.c++}
+
 - {include: '#preprocessor-rule-enabled'}
 - {include: '#preprocessor-rule-disabled'}
 - {include: '#preprocessor-rule-other'}
 - {include: '#comments'}
-- {match: \b(break|case|continue|default|do|else|for|goto|if|_Pragma|return|switch|while)\b,
-    name: keyword.control.c++}
-- {match: \b(asm|__asm__|auto|bool||char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void|size_t|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|char16_t|char32_t)\b,
-    name: storage.type.c++}
-- {match: \b(const|constexpr|extern|register|static|volatile|inline)\b, name: storage.modifier.c++}
-- {comment: common C constant naming idiom -- kConstantVariable, match: '\bk[A-Z]\w*\b',
-    name: constant.other.variable.mac-classic.c++}
-- {match: '\bg[A-Z]\w*\b', name: variable.other.readwrite.global.mac-classic.c++}
-- {match: '\bs[A-Z]\w*\b', name: variable.other.readwrite.static.mac-classic.c++}
-- {match: \b(nullptr|NULL|true|false)\b, name: constant.language.c++}
+
+  # simple keywords and type names etc
+- match: !!regex \b(break|case|continue|default|do|else|for|goto|if|_Pragma|return|switch|while)\b
+  name: keyword.control.c++
+- match: !!regex \b(asm|__asm__|auto|bool||char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void|size_t|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|char16_t|char32_t)\b
+  name: storage.type.c++
+- match: !!regex \b(const|constexpr|extern|register|static|volatile|inline)\b
+  name: storage.modifier.c++
+- match: !!regex \b(nullptr|NULL|true|false)\b
+  name: constant.language.c++}
+
+  # common C constant naming idiom -- kConstantVariable etc
+- {match: !!regex '\bk[A-Z]\w*\b', name: constant.other.variable.mac-classic.c++}
+- {match: !!regex '\bg[A-Z]\w*\b', name: variable.other.readwrite.global.mac-classic.c++}
+- {match: !!regex '\bs[A-Z]\w*\b', name: variable.other.readwrite.static.mac-classic.c++}
+
+  # types for commonly used libraries
+- match: !!regex \b(u_char|u_short|u_int|u_long|ushort|uint|u_quad_t|quad_t|qaddr_t|caddr_t|daddr_t|dev_t|fixpt_t|blkcnt_t|blksize_t|gid_t|in_addr_t|in_port_t|ino_t|key_t|mode_t|nlink_t|id_t|pid_t|off_t|segsz_t|swblk_t|uid_t|id_t|clock_t|size_t|ssize_t|time_t|useconds_t|suseconds_t)\b
+  name: support.type.sys-types.c++
+- match: !!regex \b(pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t)\b
+  name: support.type.pthread.c++
+- match: !!regex \b(int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|int_least8_t|int_least16_t|int_least32_t|int_least64_t|uint_least8_t|uint_least16_t|uint_least32_t|uint_least64_t|int_fast8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t|intptr_t|uintptr_t|intmax_t|intmax_t|uintmax_t|uintmax_t)\b
+  name: support.type.stdint.c++
+- match: !!regex \b(noErr|kNilOptions|kInvalidID|kVariableLengthArray)\b
+  name: support.constant.mac-classic.c++
+- match: !!regex \b(AbsoluteTime|Boolean|Byte|ByteCount|ByteOffset|BytePtr|CompTimeValue|ConstLogicalAddress|ConstStrFileNameParam|ConstStringPtr|Duration|Fixed|FixedPtr|Float32|Float32Point|Float64|Float80|Float96|FourCharCode|Fract|FractPtr|Handle|ItemCount|LogicalAddress|OptionBits|OSErr|OSStatus|OSType|OSTypePtr|PhysicalAddress|ProcessSerialNumber|ProcessSerialNumberPtr|ProcHandle|Ptr|ResType|ResTypePtr|ShortFixed|ShortFixedPtr|SignedByte|SInt16|SInt32|SInt64|SInt8|Size|StrFileName|StringHandle|StringPtr|TimeBase|TimeRecord|TimeScale|TimeValue|TimeValue64|UInt16|UInt32|UInt64|UInt8|UniChar|UniCharCount|UniCharCountPtr|UniCharPtr|UnicodeScalarValue|UniversalProcHandle|UniversalProcPtr|UnsignedFixed|UnsignedFixedPtr|UnsignedWide|UTF16Char|UTF32Char|UTF8Char)\b
+  name: support.type.mac-classic.c++
+
+  # storage modifiers and control keywords
+- {match: !!regex \b(friend|explicit|virtual)\b, name: storage.modifier.c++}
+- {match: !!regex '\b(private:|protected:|public:)', name: storage.modifier.c++}
+- {match: !!regex \b(catch|operator|try|throw|using)\b, name: keyword.control.c++}
+- {match: !!regex '\bdelete\b(\s*\[\])?|\bnew\b(?!])', name: keyword.control.c++}
+
+  # common C++ instance var naming idiom -- fMemberName
+- match: !!regex '\b(f|m)[A-Z]\w*\b'
+  name: variable.other.readwrite.member.c++
+
+  # keywords, templates, casting
+- match: !!regex \b(this)\b
+  name: variable.language.c++
+- match: !!regex '\btemplate(<[\s\w,<>]*>)?'
+  name: storage.type.template.c++
+- match: !!regex \b(const_cast|dynamic_cast|reinterpret_cast|static_cast)\b\s*
+  name: keyword.operator.cast.c++
+
+  # operator keywords
+- match: !!regex \b(?:and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq)\b
+  name: keyword.operator.c++
+
+  # simple matches
+- {match: !!regex \b(class|wchar_t)\b, name: storage.type.c++}
+- {match: !!regex \b(export|mutable|typename)\b, name: storage.modifier.c++}
+
+  # operators
 - {include: '#operator'}
-- {match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b',
-    name: constant.numeric.c++}
--   begin: '"'
-    beginCaptures:
-        '0': {name: punctuation.definition.string.begin.c++}
-    end: '"'
-    endCaptures:
-        '0': {name: punctuation.definition.string.end.c++}
-    name: string.quoted.double.c++
-    patterns:
-    - {include: '#string_escaped_char'}
-    - {include: '#string_placeholder'}
--   begin: ''''
-    beginCaptures:
-        '0': {name: punctuation.definition.string.begin.c++}
-    end: ''''
-    endCaptures:
-        '0': {name: punctuation.definition.string.end.c++}
-    name: string.quoted.single.c++
-    patterns:
-    - {include: '#string_escaped_char'}
+
+     ##       #### ######## ######## ########     ###    ##        ######
+     ##        ##     ##    ##       ##     ##   ## ##   ##       ##    ##
+     ##        ##     ##    ##       ##     ##  ##   ##  ##       ##
+     ##        ##     ##    ######   ########  ##     ## ##        ######
+     ##        ##     ##    ##       ##   ##   ######### ##             ##
+     ##        ##     ##    ##       ##    ##  ##     ## ##       ##    ##
+     ######## ####    ##    ######## ##     ## ##     ## ########  ######
+
+  # numeric
+- match: !!regex '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b'
+  name: constant.numeric.c++}
+  # string literal with double quotes
+- begin: '"'
+  beginCaptures:
+      '0': {name: punctuation.definition.string.begin.c++}
+  end: '"'
+  endCaptures:
+      '0': {name: punctuation.definition.string.end.c++}
+  name: string.quoted.double.c++
+  patterns:
+  - {include: '#string_escaped_char'}
+  - {include: '#string_placeholder'}
+  # string literal with single quotes
+- begin: ''''
+  beginCaptures:
+      '0': {name: punctuation.definition.string.begin.c++}
+  end: ''''
+  endCaptures:
+      '0': {name: punctuation.definition.string.end.c++}
+  name: string.quoted.single.c++
+  patterns:
+  - {include: '#string_escaped_char'}
+
+  ########  ########  ######## ########  ########   #######   ######  ########  ######   ######   #######  ########
+  ##     ## ##     ## ##       ##     ## ##     ## ##     ## ##    ## ##       ##    ## ##    ## ##     ## ##     ##
+  ##     ## ##     ## ##       ##     ## ##     ## ##     ## ##       ##       ##       ##       ##     ## ##     ##
+  ########  ########  ######   ########  ########  ##     ## ##       ######    ######   ######  ##     ## ########
+  ##        ##   ##   ##       ##        ##   ##   ##     ## ##       ##             ##       ## ##     ## ##   ##
+  ##        ##    ##  ##       ##        ##    ##  ##     ## ##    ## ##       ##    ## ##    ## ##     ## ##    ##
+  ##        ##     ## ######## ##        ##     ##  #######   ######  ########  ######   ######   #######  ##     ##
+
+  # preprocessor function #define
 -   begin: !!regex |
         (?x)
                         ^\s*\#\s*(define)\s+             # define
@@ -81,129 +161,152 @@ patterns:
     end: (?=(?://|/\*))|$
     name: meta.preprocessor.macro.c++
     patterns:
-    - {match: '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
+    - {match: !!regex '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
     - {include: $base}
--   begin: ^\s*#\s*(error|warning)\b
+
+    # preprocessor #warning and #error
+-   begin: !!regex ^\s*#\s*(error|warning)\b
     captures:
         '1': {name: keyword.control.import.error.c++}
     end: $
     name: meta.preprocessor.diagnostic.c++
     patterns:
-    - {match: '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
--   begin: ^\s*#\s*(include|import)\b\s+
+    - {match: !!regex '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
+
+    # preprocessor #import statement
+-   begin: !!regex ^\s*#\s*(include|import)\b\s+
     captures:
         '1': {name: keyword.control.import.include.c++}
     end: (?=(?://|/\*))|$
     name: meta.preprocessor.c.include
     patterns:
-    - {match: '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
-    -   begin: '"'
+    - {match: !!regex '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
+    -   begin: !!regex '"'
         beginCaptures:
             '0': {name: punctuation.definition.string.begin.c++}
         end: '"'
         endCaptures:
             '0': {name: punctuation.definition.string.end.c++}
         name: string.quoted.double.include.c++
-    -   begin: <
+    -   begin: !!regex <
         beginCaptures:
             '0': {name: punctuation.definition.string.begin.c++}
         end: '>'
         endCaptures:
             '0': {name: punctuation.definition.string.end.c++}
         name: string.quoted.other.lt-gt.include.c++
+
+  # preprocessor #pragma
 - {include: '#pragma-mark'}
--   begin: ^\s*#\s*(define|elif|else|if|ifdef|ifndef|line|pragma|undef)\b
+-   begin: !!regex ^\s*#\s*(define|elif|else|if|ifdef|ifndef|line|pragma|undef)\b
     captures:
         '1': {name: keyword.control.import.c++}
     end: (?=(?://|/\*))|$
     name: meta.preprocessor.c++
     patterns:
-    - {match: '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
-- {match: \b(u_char|u_short|u_int|u_long|ushort|uint|u_quad_t|quad_t|qaddr_t|caddr_t|daddr_t|dev_t|fixpt_t|blkcnt_t|blksize_t|gid_t|in_addr_t|in_port_t|ino_t|key_t|mode_t|nlink_t|id_t|pid_t|off_t|segsz_t|swblk_t|uid_t|id_t|clock_t|size_t|ssize_t|time_t|useconds_t|suseconds_t)\b,
-    name: support.type.sys-types.c++}
-- {match: \b(pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t)\b,
-    name: support.type.pthread.c++}
-- {match: \b(int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|int_least8_t|int_least16_t|int_least32_t|int_least64_t|uint_least8_t|uint_least16_t|uint_least32_t|uint_least64_t|int_fast8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t|intptr_t|uintptr_t|intmax_t|intmax_t|uintmax_t|uintmax_t)\b,
-    name: support.type.stdint.c++}
-- {match: \b(noErr|kNilOptions|kInvalidID|kVariableLengthArray)\b, name: support.constant.mac-classic.c++}
-- {match: \b(AbsoluteTime|Boolean|Byte|ByteCount|ByteOffset|BytePtr|CompTimeValue|ConstLogicalAddress|ConstStrFileNameParam|ConstStringPtr|Duration|Fixed|FixedPtr|Float32|Float32Point|Float64|Float80|Float96|FourCharCode|Fract|FractPtr|Handle|ItemCount|LogicalAddress|OptionBits|OSErr|OSStatus|OSType|OSTypePtr|PhysicalAddress|ProcessSerialNumber|ProcessSerialNumberPtr|ProcHandle|Ptr|ResType|ResTypePtr|ShortFixed|ShortFixedPtr|SignedByte|SInt16|SInt32|SInt64|SInt8|Size|StrFileName|StringHandle|StringPtr|TimeBase|TimeRecord|TimeScale|TimeValue|TimeValue64|UInt16|UInt32|UInt64|UInt8|UniChar|UniCharCount|UniCharCountPtr|UniCharPtr|UnicodeScalarValue|UniversalProcHandle|UniversalProcPtr|UnsignedFixed|UnsignedFixedPtr|UnsignedWide|UTF16Char|UTF32Char|UTF8Char)\b,
-    name: support.type.mac-classic.c++}
-- {include: '#block'}
--   begin: !!regex |-
-        (?x)
-                    (?:  ^                                 # begin-of-line
-                      |
-                         (?: (?= \s )           (?<!else|new|return) (?<=\w)      #  or word + space before name
-                           | (?= \s*[A-Za-z_] ) (?<!&&)       (?<=[*&>])   #  or type modifier before name
-                         )
-                    )
-                    (\s*) (?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate|sizeof|alignof)\s*\()
-                    (
-                        (?: [~A-Za-z_]\w*+ | :: | <(\w+,?\s*)++> )++ |                  # actual name
-                        (?: (?<=operator) (?: [-*&<>=+!]+ | \(\) | \[\] ) )  # if it is a C++ operator
-                    )
-                     \s*(?=\()
-    beginCaptures:
-        '1': {name: punctuation.whitespace.function.leading.c++}
-        '3': {name: entity.name.function.c++}
-        '4': {name: punctuation.definition.parameters.c++}
-    end: (?<=\})|(?=#)|(;)
-    name: meta.function.c++
-    patterns:
-    - {include: '#comments'}
-    - {include: '#parens'}
-    - {match: \b(const|override|final|noexcept)\b, name: storage.modifier.c++}
-    - {include: '#block'}
-- {match: \b(friend|explicit|virtual)\b, name: storage.modifier.c++}
-- {match: '\b(private:|protected:|public:)', name: storage.modifier.c++}
-- {match: \b(catch|operator|try|throw|using)\b, name: keyword.control.c++}
-- {match: '\bdelete\b(\s*\[\])?|\bnew\b(?!])', name: keyword.control.c++}
-- {comment: common C++ instance var naming idiom -- fMemberName, match: '\b(f|m)[A-Z]\w*\b',
-    name: variable.other.readwrite.member.c++}
-- {match: \b(this)\b, name: variable.language.c++}
-- {match: '\btemplate(<[\s\w,<>]*>)?', name: storage.type.template.c++}
-- {match: \b(const_cast|dynamic_cast|reinterpret_cast|static_cast)\b\s*, name: keyword.operator.cast.c++}
--   match: !!regex |-
-        (?x)(
-                        \b(?:and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq)\b
-                    )
-    name: keyword.operator.c++
-- {match: \b(class|wchar_t)\b, name: storage.type.c++}
-- {match: \b(export|mutable|typename)\b, name: storage.modifier.c++}
--   begin: !!regex |
-        (?x)
-                            (?:  ^                                 # begin-of-line
-                              |  (?: (?<!else|new|=) )             #  or word + space before name
-                            )
-                            ((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
-                             \s*(\()                           # start bracket or end-of-line
-    beginCaptures:
-        '1': {name: entity.name.function.c++}
-        '2': {name: punctuation.definition.parameters.c++}
-    end: \)
-    endCaptures:
-        '0': {name: punctuation.definition.parameters.c++}
-    name: meta.function.destructor.c++
-    patterns:
-    - {include: $base}
--   begin: !!regex |
-        (?x)
-                            (?:  ^                                 # begin-of-line
-                              |  (?: (?<!else|new|=) )             #  or word + space before name
-                            )
-                            ((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
-                             \s*(\()                           # terminating semi-colon
-    beginCaptures:
-        '1': {name: entity.name.function.c++}
-        '2': {name: punctuation.definition.parameters.c++}
-    end: \)
-    endCaptures:
-        '0': {name: punctuation.definition.parameters.c++}
-    name: meta.function.destructor.prototype.c++
-    patterns:
-    - {include: $base}
+    - {match: !!regex '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
+
+
+
+  # FIXME why is block included twice?
+- include: '#block'
+
+    ######## ##     ## ##    ##  ######  ######## ####  #######  ##    ##  ######
+    ##       ##     ## ###   ## ##    ##    ##     ##  ##     ## ###   ## ##    ##
+    ##       ##     ## ####  ## ##          ##     ##  ##     ## ####  ## ##
+    ######   ##     ## ## ## ## ##          ##     ##  ##     ## ## ## ##  ######
+    ##       ##     ## ##  #### ##          ##     ##  ##     ## ##  ####       ##
+    ##       ##     ## ##   ### ##    ##    ##     ##  ##     ## ##   ### ##    ##
+    ##        #######  ##    ##  ######     ##    ####  #######  ##    ##  ######
+
+  # function implementation
+- begin: !!regex |-
+      (?x)
+                  (?:  ^                                                        # begin-of-line
+                    |
+                       (?: (?= \s )           (?<!else|new|return) (?<=\w)      #  or word + space before name
+                         | (?= \s*[A-Za-z_] ) (?<!&&)       (?<=[*&>])          #  or type modifier before name
+                       )
+                  )
+                  (\s*) (?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate|sizeof|alignof)\s*\()
+                  (
+                      (?: [A-Za-z_]\w*+ | :: | <(\w+,?\s*)++> )++ |            # actual name
+                      (?: (?<=operator) (?: [-*&<>=+!]+ | \(\) | \[\] ) )       # if it is a C++ operator
+                  )
+                   \s*(?=\()
+  beginCaptures:
+      '1': {name: punctuation.whitespace.function.leading.c++}
+      '3': {name: entity.name.function.c++}
+      '4': {name: punctuation.definition.parameters.c++}
+  end: !!regex (?<=\})|(?=#)|(;)
+  name: meta.function.c++
+  patterns:
+  - {include: '#comments'}
+  - {include: '#parens'}
+  - {match: !!regex \b(const|override|final|noexcept)\b, name: storage.modifier.c++}
+  - {include: '#block'}
+
+
+  # destructor function definition (starts with ~)
+- begin: !!regex |
+      (?x)
+            (?:  ^                                 # begin-of-line
+              |  (?: (?<!else|new|=) )             #  or word + space before name
+            )
+            ((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
+             \s*(\()                           # start bracket or end-of-line
+  beginCaptures:
+      '1': {name: entity.name.function.c++}
+      '2': {name: punctuation.definition.parameters.c++}
+  end: \)
+  endCaptures:
+      '0': {name: punctuation.definition.parameters.c++}
+  name: meta.function.destructor.c++
+  patterns:
+  - {include: $base}
+
+  # destructor prototype
+- begin: !!regex |
+      (?x)
+                          (?:  ^                                 # begin-of-line
+                            |  (?: (?<!else|new|=) )             #  or word + space before name
+                          )
+                          ((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
+                           \s*(\()                           # terminating semi-colon
+  beginCaptures:
+      '1': {name: entity.name.function.c++}
+      '2': {name: punctuation.definition.parameters.c++}
+  end: \)
+  endCaptures:
+      '0': {name: punctuation.definition.parameters.c++}
+  name: meta.function.destructor.prototype.c++
+  patterns:
+  - {include: $base}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+########  ######## ########   #######   ######  #### ########  #######  ########  ##    ##
+##     ## ##       ##     ## ##     ## ##    ##  ##     ##    ##     ## ##     ##  ##  ##
+##     ## ##       ##     ## ##     ## ##        ##     ##    ##     ## ##     ##   ####
+########  ######   ########  ##     ##  ######   ##     ##    ##     ## ########     ##
+##   ##   ##       ##        ##     ##       ##  ##     ##    ##     ## ##   ##      ##
+##    ##  ##       ##        ##     ## ##    ##  ##     ##    ##     ## ##    ##     ##
+##     ## ######## ##         #######   ######  ####    ##     #######  ##     ##    ##
+
+# rules which are referenced elsewhere in the grammar
 repository:
-    access: {match: '\.[a-zA-Z_]\w*\b(?!\s*\()|\->[a-zA-Z_]\w*\b(?!\s*\()', name: variable.other.dot-access.c++}
+    access: {match: !!regex '\.[a-zA-Z_]\w*\b(?!\s*\()|\->[a-zA-Z_]\w*\b(?!\s*\()', name: variable.other.dot-access.c++}
     angle_brackets:
         begin: <
         end: '>'
@@ -227,7 +330,7 @@ repository:
         -   captures:
                 '1': {name: punctuation.whitespace.support.function.leading.c++}
                 '2': {name: support.function.C99.c++}
-            match: (\s*)\b(hypot(f|l)?|s(scanf|ystem|nprintf|ca(nf|lb(n(f|l)?|ln(f|l)?))|i(n(h(f|l)?|f|l)?|gn(al|bit))|tr(s(tr|pn)|nc(py|at|mp)|c(spn|hr|oll|py|at|mp)|to(imax|d|u(l(l)?|max)|k|f|l(d|l)?)|error|pbrk|ftime|len|rchr|xfrm)|printf|et(jmp|vbuf|locale|buf)|qrt(f|l)?|w(scanf|printf)|rand)|n(e(arbyint(f|l)?|xt(toward(f|l)?|after(f|l)?))|an(f|l)?)|c(s(in(h(f|l)?|f|l)?|qrt(f|l)?)|cos(h(f)?|f|l)?|imag(f|l)?|t(ime|an(h(f|l)?|f|l)?)|o(s(h(f|l)?|f|l)?|nj(f|l)?|pysign(f|l)?)|p(ow(f|l)?|roj(f|l)?)|e(il(f|l)?|xp(f|l)?)|l(o(ck|g(f|l)?)|earerr)|a(sin(h(f|l)?|f|l)?|cos(h(f|l)?|f|l)?|tan(h(f|l)?|f|l)?|lloc|rg(f|l)?|bs(f|l)?)|real(f|l)?|brt(f|l)?)|t(ime|o(upper|lower)|an(h(f|l)?|f|l)?|runc(f|l)?|gamma(f|l)?|mp(nam|file))|i(s(space|n(ormal|an)|cntrl|inf|digit|u(nordered|pper)|p(unct|rint)|finite|w(space|c(ntrl|type)|digit|upper|p(unct|rint)|lower|al(num|pha)|graph|xdigit|blank)|l(ower|ess(equal|greater)?)|al(num|pha)|gr(eater(equal)?|aph)|xdigit|blank)|logb(f|l)?|max(div|abs))|di(v|fftime)|_Exit|unget(c|wc)|p(ow(f|l)?|ut(s|c(har)?|wc(har)?)|error|rintf)|e(rf(c(f|l)?|f|l)?|x(it|p(2(f|l)?|f|l|m1(f|l)?)?))|v(s(scanf|nprintf|canf|printf|w(scanf|printf))|printf|f(scanf|printf|w(scanf|printf))|w(scanf|printf)|a_(start|copy|end|arg))|qsort|f(s(canf|e(tpos|ek))|close|tell|open|dim(f|l)?|p(classify|ut(s|c|w(s|c))|rintf)|e(holdexcept|set(e(nv|xceptflag)|round)|clearexcept|testexcept|of|updateenv|r(aiseexcept|ror)|get(e(nv|xceptflag)|round))|flush|w(scanf|ide|printf|rite)|loor(f|l)?|abs(f|l)?|get(s|c|pos|w(s|c))|re(open|e|ad|xp(f|l)?)|m(in(f|l)?|od(f|l)?|a(f|l|x(f|l)?)?))|l(d(iv|exp(f|l)?)|o(ngjmp|cal(time|econv)|g(1(p(f|l)?|0(f|l)?)|2(f|l)?|f|l|b(f|l)?)?)|abs|l(div|abs|r(int(f|l)?|ound(f|l)?))|r(int(f|l)?|ound(f|l)?)|gamma(f|l)?)|w(scanf|c(s(s(tr|pn)|nc(py|at|mp)|c(spn|hr|oll|py|at|mp)|to(imax|d|u(l(l)?|max)|k|f|l(d|l)?|mbs)|pbrk|ftime|len|r(chr|tombs)|xfrm)|to(b|mb)|rtomb)|printf|mem(set|c(hr|py|mp)|move))|a(s(sert|ctime|in(h(f|l)?|f|l)?)|cos(h(f|l)?|f|l)?|t(o(i|f|l(l)?)|exit|an(h(f|l)?|2(f|l)?|f|l)?)|b(s|ort))|g(et(s|c(har)?|env|wc(har)?)|mtime)|r(int(f|l)?|ound(f|l)?|e(name|alloc|wind|m(ove|quo(f|l)?|ainder(f|l)?))|a(nd|ise))|b(search|towc)|m(odf(f|l)?|em(set|c(hr|py|mp)|move)|ktime|alloc|b(s(init|towcs|rtowcs)|towc|len|r(towc|len))))\b
+            match: !!regex (\s*)\b(hypot(f|l)?|s(scanf|ystem|nprintf|ca(nf|lb(n(f|l)?|ln(f|l)?))|i(n(h(f|l)?|f|l)?|gn(al|bit))|tr(s(tr|pn)|nc(py|at|mp)|c(spn|hr|oll|py|at|mp)|to(imax|d|u(l(l)?|max)|k|f|l(d|l)?)|error|pbrk|ftime|len|rchr|xfrm)|printf|et(jmp|vbuf|locale|buf)|qrt(f|l)?|w(scanf|printf)|rand)|n(e(arbyint(f|l)?|xt(toward(f|l)?|after(f|l)?))|an(f|l)?)|c(s(in(h(f|l)?|f|l)?|qrt(f|l)?)|cos(h(f)?|f|l)?|imag(f|l)?|t(ime|an(h(f|l)?|f|l)?)|o(s(h(f|l)?|f|l)?|nj(f|l)?|pysign(f|l)?)|p(ow(f|l)?|roj(f|l)?)|e(il(f|l)?|xp(f|l)?)|l(o(ck|g(f|l)?)|earerr)|a(sin(h(f|l)?|f|l)?|cos(h(f|l)?|f|l)?|tan(h(f|l)?|f|l)?|lloc|rg(f|l)?|bs(f|l)?)|real(f|l)?|brt(f|l)?)|t(ime|o(upper|lower)|an(h(f|l)?|f|l)?|runc(f|l)?|gamma(f|l)?|mp(nam|file))|i(s(space|n(ormal|an)|cntrl|inf|digit|u(nordered|pper)|p(unct|rint)|finite|w(space|c(ntrl|type)|digit|upper|p(unct|rint)|lower|al(num|pha)|graph|xdigit|blank)|l(ower|ess(equal|greater)?)|al(num|pha)|gr(eater(equal)?|aph)|xdigit|blank)|logb(f|l)?|max(div|abs))|di(v|fftime)|_Exit|unget(c|wc)|p(ow(f|l)?|ut(s|c(har)?|wc(har)?)|error|rintf)|e(rf(c(f|l)?|f|l)?|x(it|p(2(f|l)?|f|l|m1(f|l)?)?))|v(s(scanf|nprintf|canf|printf|w(scanf|printf))|printf|f(scanf|printf|w(scanf|printf))|w(scanf|printf)|a_(start|copy|end|arg))|qsort|f(s(canf|e(tpos|ek))|close|tell|open|dim(f|l)?|p(classify|ut(s|c|w(s|c))|rintf)|e(holdexcept|set(e(nv|xceptflag)|round)|clearexcept|testexcept|of|updateenv|r(aiseexcept|ror)|get(e(nv|xceptflag)|round))|flush|w(scanf|ide|printf|rite)|loor(f|l)?|abs(f|l)?|get(s|c|pos|w(s|c))|re(open|e|ad|xp(f|l)?)|m(in(f|l)?|od(f|l)?|a(f|l|x(f|l)?)?))|l(d(iv|exp(f|l)?)|o(ngjmp|cal(time|econv)|g(1(p(f|l)?|0(f|l)?)|2(f|l)?|f|l|b(f|l)?)?)|abs|l(div|abs|r(int(f|l)?|ound(f|l)?))|r(int(f|l)?|ound(f|l)?)|gamma(f|l)?)|w(scanf|c(s(s(tr|pn)|nc(py|at|mp)|c(spn|hr|oll|py|at|mp)|to(imax|d|u(l(l)?|max)|k|f|l(d|l)?|mbs)|pbrk|ftime|len|r(chr|tombs)|xfrm)|to(b|mb)|rtomb)|printf|mem(set|c(hr|py|mp)|move))|a(s(sert|ctime|in(h(f|l)?|f|l)?)|cos(h(f|l)?|f|l)?|t(o(i|f|l(l)?)|exit|an(h(f|l)?|2(f|l)?|f|l)?)|b(s|ort))|g(et(s|c(har)?|env|wc(har)?)|mtime)|r(int(f|l)?|ound(f|l)?|e(name|alloc|wind|m(ove|quo(f|l)?|ainder(f|l)?))|a(nd|ise))|b(search|towc)|m(odf(f|l)?|em(set|c(hr|py|mp)|move)|ktime|alloc|b(s(init|towcs|rtowcs)|towc|len|r(towc|len))))\b
         -   captures:
                 '1': {name: punctuation.whitespace.function-call.leading.c++}
                 '2': {name: entity.name.function.c++}
@@ -261,25 +364,25 @@ repository:
         patterns:
         -   captures:
                 '1': {name: meta.toc-list.banner.block.c++}
-            match: ^/\* =(\s*.*?)\s*= \*/$\n?
+            match: !!regex ^/\* =(\s*.*?)\s*= \*/$\n?
             name: comment.block.c++
-        -   begin: /\*
+        -   begin: !!regex /\*
             captures:
                 '0': {name: punctuation.definition.comment.c++}
             end: \*/
             name: comment.block.c++
-        - {match: \*/.*\n, name: invalid.illegal.stray-comment-end.c++}
+        - {match: !!regex \*/.*\n, name: invalid.illegal.stray-comment-end.c++}
         -   captures:
                 '1': {name: meta.toc-list.banner.line.c++}
-            match: ^// =(\s*.*?)\s*=\s*$\n?
+            match: !!regex ^// =(\s*.*?)\s*=\s*$\n?
             name: comment.line.banner.c++
-        -   begin: //
+        -   begin: !!regex //
             beginCaptures:
                 '0': {name: punctuation.definition.comment.c++}
             end: $\n?
             name: comment.line.double-slash.c++
             patterns:
-            - {match: '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
+            - {match: !!regex '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
     constructor:
         patterns:
         -   begin: !!regex |
@@ -308,15 +411,15 @@ repository:
             patterns:
             - {include: $base}
     disabled:
-        begin: ^\s*#\s*if(n?def)?\b.*$
+        begin: !!regex ^\s*#\s*if(n?def)?\b.*$
         comment: eat nested preprocessor if(def)s
         end: ^\s*#\s*endif\b.*$
         patterns:
         - {include: '#disabled'}
         - {include: '#pragma-mark'}
-    operator: {match: \b(sizeof|alignof)\b, name: keyword.operator.function.c++}
+    operator: {match: !!regex \b(sizeof|alignof)\b, name: keyword.operator.function.c++}
     parens:
-        begin: \(
+        begin: !!regex \(
         end: \)
         name: meta.parens.c++
         patterns:
@@ -326,59 +429,59 @@ repository:
             '1': {name: meta.preprocessor.c++}
             '2': {name: keyword.control.import.pragma.c++}
             '3': {name: meta.toc-list.pragma-mark.c++}
-        match: ^\s*(#\s*(pragma\s+mark)\s+(.*))
+        match: !!regex ^\s*(#\s*(pragma\s+mark)\s+(.*))
         name: meta.section
     preprocessor-rule-disabled:
-        begin: ^\s*(#(if)\s+(0)\b).*
+        begin: !!regex ^\s*(#(if)\s+(0)\b).*
         captures:
             '1': {name: meta.preprocessor.c++}
             '2': {name: keyword.control.import.if.c++}
             '3': {name: constant.numeric.preprocessor.c++}
         end: ^\s*(#\s*(endif)\b)
         patterns:
-        -   begin: ^\s*(#\s*(else)\b)
+        -   begin: !!regex ^\s*(#\s*(else)\b)
             captures:
                 '1': {name: meta.preprocessor.c++}
                 '2': {name: keyword.control.import.else.c++}
             end: (?=^\s*#\s*endif\b.*$)
             patterns:
             - {include: $base}
-        -   begin: ''
+        -   begin: !!regex ''
             end: (?=^\s*#\s*(else|endif)\b.*$)
             name: comment.block.preprocessor.if-branch
             patterns:
             - {include: '#disabled'}
             - {include: '#pragma-mark'}
     preprocessor-rule-disabled-block:
-        begin: ^\s*(#(if)\s+(0)\b).*
+        begin: !!regex ^\s*(#(if)\s+(0)\b).*
         captures:
             '1': {name: meta.preprocessor.c++}
             '2': {name: keyword.control.import.if.c++}
             '3': {name: constant.numeric.preprocessor.c++}
         end: ^\s*(#\s*(endif)\b)
         patterns:
-        -   begin: ^\s*(#\s*(else)\b)
+        -   begin: !!regex ^\s*(#\s*(else)\b)
             captures:
                 '1': {name: meta.preprocessor.c++}
                 '2': {name: keyword.control.import.else.c++}
             end: (?=^\s*#\s*endif\b.*$)
             patterns:
             - {include: '#block_innards'}
-        -   begin: ''
+        -   begin: !!regex ''
             end: (?=^\s*#\s*(else|endif)\b.*$)
             name: comment.block.preprocessor.if-branch.in-block
             patterns:
             - {include: '#disabled'}
             - {include: '#pragma-mark'}
     preprocessor-rule-enabled:
-        begin: ^\s*(#(if)\s+(0*1)\b)
+        begin: !!regex ^\s*(#(if)\s+(0*1)\b)
         captures:
             '1': {name: meta.preprocessor.c++}
             '2': {name: keyword.control.import.if.c++}
             '3': {name: constant.numeric.preprocessor.c++}
         end: ^\s*(#\s*(endif)\b)
         patterns:
-        -   begin: ^\s*(#\s*(else)\b).*
+        -   begin: !!regex ^\s*(#\s*(else)\b).*
             captures:
                 '1': {name: meta.preprocessor.c++}
                 '2': {name: keyword.control.import.else.c++}
@@ -387,19 +490,19 @@ repository:
             patterns:
             - {include: '#disabled'}
             - {include: '#pragma-mark'}
-        -   begin: ''
+        -   begin: !!regex ''
             end: (?=^\s*#\s*(else|endif)\b.*$)
             patterns:
             - {include: $base}
     preprocessor-rule-enabled-block:
-        begin: ^\s*(#(if)\s+(0*1)\b)
+        begin: !!regex ^\s*(#(if)\s+(0*1)\b)
         captures:
             '1': {name: meta.preprocessor.c++}
             '2': {name: keyword.control.import.if.c++}
             '3': {name: constant.numeric.preprocessor.c++}
         end: ^\s*(#\s*(endif)\b)
         patterns:
-        -   begin: ^\s*(#\s*(else)\b).*
+        -   begin: !!regex ^\s*(#\s*(else)\b).*
             captures:
                 '1': {name: meta.preprocessor.c++}
                 '2': {name: keyword.control.import.else.c++}
@@ -408,12 +511,12 @@ repository:
             patterns:
             - {include: '#disabled'}
             - {include: '#pragma-mark'}
-        -   begin: ''
+        -   begin: !!regex ''
             end: (?=^\s*#\s*(else|endif)\b.*$)
             patterns:
             - {include: '#block_innards'}
     preprocessor-rule-other:
-        begin: ^\s*(#\s*(if(n?def)?)\b.*?(?:(?=(?://|/\*))|$))
+        begin: !!regex ^\s*(#\s*(if(n?def)?)\b.*?(?:(?=(?://|/\*))|$))
         captures:
             '1': {name: meta.preprocessor.c++}
             '2': {name: keyword.control.import.c++}
@@ -421,7 +524,7 @@ repository:
         patterns:
         - {include: $base}
     preprocessor-rule-other-block:
-        begin: ^\s*(#\s*(if(n?def)?)\b.*?(?:(?=(?://|/\*))|$))
+        begin: !!regex ^\s*(#\s*(if(n?def)?)\b.*?(?:(?=(?://|/\*))|$))
         captures:
             '1': {name: meta.preprocessor.c++}
             '2': {name: keyword.control.import.c++}
@@ -433,9 +536,9 @@ repository:
         -   captures:
                 '1': {name: keyword.control.namespace.c++}
                 '2': {name: entity.name.section.namespace.c++}
-            match: (?mx)\b(namespace)\s+((?:[a-zA-Z_][a-zA-Z0-9_:]*)+)?
+            match: !!regex (?mx)\b(namespace)\s+((?:[a-zA-Z_][a-zA-Z0-9_:]*)+)?
             name: meta.namespace-decl.c++
-        -   begin: \b(class|struct)\s+([_A-Za-z][_A-Za-z0-9]*\b)
+        -   begin: !!regex \b(class|struct)\s+([_A-Za-z][_A-Za-z0-9]*\b)
             beginCaptures:
                 '1': {name: storage.type.c++}
                 '2': {name: entity.name.type.c++}
@@ -443,7 +546,7 @@ repository:
             name: meta.class-struct-block.c++
             patterns:
             - {include: '#angle_brackets'}
-            -   begin: (\{)
+            -   begin: !!regex (\{)
                 beginCaptures:
                     '1': {name: punctuation.definition.scope.c++}
                 end: (\})(\s*\n)?
@@ -455,13 +558,13 @@ repository:
                 - {include: '#constructor'}
                 - {include: $base}
             - {include: $base}
-        -   begin: \b(extern)(?=\s*")
+        -   begin: !!regex \b(extern)(?=\s*")
             beginCaptures:
                 '1': {name: storage.modifier.c++}
             end: (?<=\})|(?=\w)
             name: meta.extern-block.c++
             patterns:
-            -   begin: \{
+            -   begin: !!regex \{
                 end: \}
                 patterns:
                 - {include: '#special_block'}
@@ -469,9 +572,9 @@ repository:
             - {include: $base}
     string_escaped_char:
         patterns:
-        - {match: '\\(\\|[abefnprtv''"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})',
+        - {match: !!regex '\\(\\|[abefnprtv''"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})',
             name: constant.character.escape.c++}
-        - {match: \\., name: invalid.illegal.unknown-escape.c++}
+        - {match: !!regex \\., name: invalid.illegal.unknown-escape.c++}
     string_placeholder:
         patterns:
         -   match: !!regex |
@@ -484,6 +587,12 @@ repository:
                                             (hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier
                                             [diouxXDOUeEfFgGaACcSspn%]           # conversion type
             name: constant.other.placeholder.c++
-        - {match: '%', name: invalid.illegal.placeholder.c++}
+        - {match: !!regex '%', name: invalid.illegal.placeholder.c++}
+
+
+
+
+
+
 scopeName: source.c++
 uuid: 26251B18-6B1D-11D9-AFDB-000D93589AF6

--- a/C++11.tmLanguage.YAML
+++ b/C++11.tmLanguage.YAML
@@ -58,7 +58,7 @@ patterns:
     name: string.quoted.single.c++
     patterns:
     - {include: '#string_escaped_char'}
--   begin: |
+-   begin: !!regex |
         (?x)
                         ^\s*\#\s*(define)\s+             # define
                         ((?<id>[a-zA-Z_]\w*))  # macro name
@@ -129,7 +129,7 @@ patterns:
 - {match: \b(AbsoluteTime|Boolean|Byte|ByteCount|ByteOffset|BytePtr|CompTimeValue|ConstLogicalAddress|ConstStrFileNameParam|ConstStringPtr|Duration|Fixed|FixedPtr|Float32|Float32Point|Float64|Float80|Float96|FourCharCode|Fract|FractPtr|Handle|ItemCount|LogicalAddress|OptionBits|OSErr|OSStatus|OSType|OSTypePtr|PhysicalAddress|ProcessSerialNumber|ProcessSerialNumberPtr|ProcHandle|Ptr|ResType|ResTypePtr|ShortFixed|ShortFixedPtr|SignedByte|SInt16|SInt32|SInt64|SInt8|Size|StrFileName|StringHandle|StringPtr|TimeBase|TimeRecord|TimeScale|TimeValue|TimeValue64|UInt16|UInt32|UInt64|UInt8|UniChar|UniCharCount|UniCharCountPtr|UniCharPtr|UnicodeScalarValue|UniversalProcHandle|UniversalProcPtr|UnsignedFixed|UnsignedFixedPtr|UnsignedWide|UTF16Char|UTF32Char|UTF8Char)\b,
     name: support.type.mac-classic.c++}
 - {include: '#block'}
--   begin: |-
+-   begin: !!regex |-
         (?x)
                     (?:  ^                                 # begin-of-line
                       |
@@ -170,7 +170,7 @@ patterns:
     name: keyword.operator.c++
 - {match: \b(class|wchar_t)\b, name: storage.type.c++}
 - {match: \b(export|mutable|typename)\b, name: storage.modifier.c++}
--   begin: |
+-   begin: !!regex |
         (?x)
                             (?:  ^                                 # begin-of-line
                               |  (?: (?<!else|new|=) )             #  or word + space before name
@@ -186,7 +186,7 @@ patterns:
     name: meta.function.destructor.c++
     patterns:
     - {include: $base}
--   begin: |
+-   begin: !!regex |
         (?x)
                             (?:  ^                                 # begin-of-line
                               |  (?: (?<!else|new|=) )             #  or word + space before name
@@ -282,7 +282,7 @@ repository:
             - {match: '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
     constructor:
         patterns:
-        -   begin: |
+        -   begin: !!regex |
                 (?x)
                                     (?:  ^\s*)                             # begin-of-line
                                     ((?!while|for|do|if|else|switch|catch|enumerate|r?iterate|sizeof|alignof)[A-Za-z_][A-Za-z0-9_:]*) # actual name
@@ -296,7 +296,7 @@ repository:
             name: meta.function.constructor.c++
             patterns:
             - {include: $base}
-        -   begin: |
+        -   begin: !!regex |
                 (?x)
                                     (:)                            # begin-of-line
                                     ((?=\s*[A-Za-z_][A-Za-z0-9_:]* # actual name

--- a/C++11.tmLanguage.YAML
+++ b/C++11.tmLanguage.YAML
@@ -61,7 +61,7 @@ patterns:
 -   begin: !!regex |
         (?x)
                         ^\s*\#\s*(define)\s+             # define
-                        ((?<id>[a-zA-Z_]\w*))  # macro name
+                        ((?<id>[a-zA-Z_]\w*))            # macro name
                         (?:                              # and optionally:
                             (\()                         # an open parenthesis
                                 (

--- a/C++11.tmLanguage.YAML
+++ b/C++11.tmLanguage.YAML
@@ -163,7 +163,7 @@ patterns:
 - {match: \b(this)\b, name: variable.language.c++}
 - {match: '\btemplate(<[\s\w,<>]*>)?', name: storage.type.template.c++}
 - {match: \b(const_cast|dynamic_cast|reinterpret_cast|static_cast)\b\s*, name: keyword.operator.cast.c++}
--   match: |-
+-   match: !!regex |-
         (?x)(
                         \b(?:and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq)\b
                     )
@@ -232,7 +232,7 @@ repository:
                 '1': {name: punctuation.whitespace.function-call.leading.c++}
                 '2': {name: entity.name.function.c++}
                 '3': {name: punctuation.definition.parameters.c++}
-            match: |-
+            match: !!regex |-
                 (?x) (?: (?= \s )  (?:(?<=else|new|return) | (?<!\w)) (\s+))?
                             (\b
                                 (?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate|sizeof|alignof)\s*\()(?:(?!NS)[A-Za-z_]\w*+\b | :: )++                  # actual name
@@ -242,7 +242,7 @@ repository:
         -   captures:
                 '1': {name: variable.other.c++}
                 '2': {name: punctuation.definition.parameters.c++}
-            match: |-
+            match: !!regex |-
                 (?x)
                                     (?x)
                             (?:
@@ -474,7 +474,7 @@ repository:
         - {match: \\., name: invalid.illegal.unknown-escape.c++}
     string_placeholder:
         patterns:
-        -   match: |
+        -   match: !!regex |
                 (?x)%
                                             (\d+\$)?                             # field (argument #)
                                             [#0\- +']*                           # flags

--- a/C++11.tmLanguage.YAML
+++ b/C++11.tmLanguage.YAML
@@ -1,0 +1,489 @@
+comment: Incomplete C++11 tmLanguage
+fileTypes: [cpp, cc, tcc, cp, cxx, c++, hh, thh, hpp, hxx, h++, inl, ipp]
+firstLineMatch: -\*- C\+\+ -\*-
+foldingStartMarker: |
+    (?x)
+             /\*\*(?!\*)
+            |^(?![^{]*?//|[^{]*?/\*(?!.*?\*/.*?\{)).*?\{\s*($|//|/\*(?!.*?\*/.*\S))
+foldingStopMarker: (?<!\*)\*\*/|^\s*\}
+keyEquivalent: ^~C
+name: C++11
+patterns:
+- {include: '#special_block'}
+- {include: '#block'}
+-   begin: R"([a-zA-Z_]\w*)?\(
+    beginCaptures:
+        '0': {name: punctuation.definition.string.begin.raw.c++}
+    end: \)\1?"
+    endCaptures:
+        '0': {name: punctuation.definition.string.end.raw.c++}
+    name: string.quoted.raw.c++
+    patterns:
+    - {include: '#string_escaped_char'}
+    - {include: '#string_placeholder'}
+- {match: \b(constexpr|auto)\b, name: storage.modifier.c++}
+- {include: '#preprocessor-rule-enabled'}
+- {include: '#preprocessor-rule-disabled'}
+- {include: '#preprocessor-rule-other'}
+- {include: '#comments'}
+- {match: \b(break|case|continue|default|do|else|for|goto|if|_Pragma|return|switch|while)\b,
+    name: keyword.control.c++}
+- {match: \b(asm|__asm__|auto|bool||char|_Complex|double|enum|float|_Imaginary|int|long|short|signed|struct|typedef|union|unsigned|void|size_t|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|char16_t|char32_t)\b,
+    name: storage.type.c++}
+- {match: \b(const|constexpr|extern|register|static|volatile|inline)\b, name: storage.modifier.c++}
+- {comment: common C constant naming idiom -- kConstantVariable, match: '\bk[A-Z]\w*\b',
+    name: constant.other.variable.mac-classic.c++}
+- {match: '\bg[A-Z]\w*\b', name: variable.other.readwrite.global.mac-classic.c++}
+- {match: '\bs[A-Z]\w*\b', name: variable.other.readwrite.static.mac-classic.c++}
+- {match: \b(nullptr|NULL|true|false)\b, name: constant.language.c++}
+- {include: '#operator'}
+- {match: '\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b',
+    name: constant.numeric.c++}
+-   begin: '"'
+    beginCaptures:
+        '0': {name: punctuation.definition.string.begin.c++}
+    end: '"'
+    endCaptures:
+        '0': {name: punctuation.definition.string.end.c++}
+    name: string.quoted.double.c++
+    patterns:
+    - {include: '#string_escaped_char'}
+    - {include: '#string_placeholder'}
+-   begin: ''''
+    beginCaptures:
+        '0': {name: punctuation.definition.string.begin.c++}
+    end: ''''
+    endCaptures:
+        '0': {name: punctuation.definition.string.end.c++}
+    name: string.quoted.single.c++
+    patterns:
+    - {include: '#string_escaped_char'}
+-   begin: |
+        (?x)
+                        ^\s*\#\s*(define)\s+             # define
+                        ((?<id>[a-zA-Z_]\w*))  # macro name
+                        (?:                              # and optionally:
+                            (\()                         # an open parenthesis
+                                (
+                                    \s* \g<id> \s*       # first argument
+                                    ((,) \s* \g<id> \s*)*  # additional arguments
+                                    (?:\.\.\.)?          # varargs ellipsis?
+                                )
+                            (\))                         # a close parenthesis
+                        )?
+    beginCaptures:
+        '1': {name: keyword.control.import.define.c++}
+        '2': {name: entity.name.function.preprocessor.c++}
+        '4': {name: punctuation.definition.parameters.c++}
+        '5': {name: variable.parameter.preprocessor.c++}
+        '7': {name: punctuation.separator.parameters.c++}
+        '8': {name: punctuation.definition.parameters.c++}
+    end: (?=(?://|/\*))|$
+    name: meta.preprocessor.macro.c++
+    patterns:
+    - {match: '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
+    - {include: $base}
+-   begin: ^\s*#\s*(error|warning)\b
+    captures:
+        '1': {name: keyword.control.import.error.c++}
+    end: $
+    name: meta.preprocessor.diagnostic.c++
+    patterns:
+    - {match: '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
+-   begin: ^\s*#\s*(include|import)\b\s+
+    captures:
+        '1': {name: keyword.control.import.include.c++}
+    end: (?=(?://|/\*))|$
+    name: meta.preprocessor.c.include
+    patterns:
+    - {match: '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
+    -   begin: '"'
+        beginCaptures:
+            '0': {name: punctuation.definition.string.begin.c++}
+        end: '"'
+        endCaptures:
+            '0': {name: punctuation.definition.string.end.c++}
+        name: string.quoted.double.include.c++
+    -   begin: <
+        beginCaptures:
+            '0': {name: punctuation.definition.string.begin.c++}
+        end: '>'
+        endCaptures:
+            '0': {name: punctuation.definition.string.end.c++}
+        name: string.quoted.other.lt-gt.include.c++
+- {include: '#pragma-mark'}
+-   begin: ^\s*#\s*(define|elif|else|if|ifdef|ifndef|line|pragma|undef)\b
+    captures:
+        '1': {name: keyword.control.import.c++}
+    end: (?=(?://|/\*))|$
+    name: meta.preprocessor.c++
+    patterns:
+    - {match: '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
+- {match: \b(u_char|u_short|u_int|u_long|ushort|uint|u_quad_t|quad_t|qaddr_t|caddr_t|daddr_t|dev_t|fixpt_t|blkcnt_t|blksize_t|gid_t|in_addr_t|in_port_t|ino_t|key_t|mode_t|nlink_t|id_t|pid_t|off_t|segsz_t|swblk_t|uid_t|id_t|clock_t|size_t|ssize_t|time_t|useconds_t|suseconds_t)\b,
+    name: support.type.sys-types.c++}
+- {match: \b(pthread_attr_t|pthread_cond_t|pthread_condattr_t|pthread_mutex_t|pthread_mutexattr_t|pthread_once_t|pthread_rwlock_t|pthread_rwlockattr_t|pthread_t|pthread_key_t)\b,
+    name: support.type.pthread.c++}
+- {match: \b(int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|int_least8_t|int_least16_t|int_least32_t|int_least64_t|uint_least8_t|uint_least16_t|uint_least32_t|uint_least64_t|int_fast8_t|int_fast16_t|int_fast32_t|int_fast64_t|uint_fast8_t|uint_fast16_t|uint_fast32_t|uint_fast64_t|intptr_t|uintptr_t|intmax_t|intmax_t|uintmax_t|uintmax_t)\b,
+    name: support.type.stdint.c++}
+- {match: \b(noErr|kNilOptions|kInvalidID|kVariableLengthArray)\b, name: support.constant.mac-classic.c++}
+- {match: \b(AbsoluteTime|Boolean|Byte|ByteCount|ByteOffset|BytePtr|CompTimeValue|ConstLogicalAddress|ConstStrFileNameParam|ConstStringPtr|Duration|Fixed|FixedPtr|Float32|Float32Point|Float64|Float80|Float96|FourCharCode|Fract|FractPtr|Handle|ItemCount|LogicalAddress|OptionBits|OSErr|OSStatus|OSType|OSTypePtr|PhysicalAddress|ProcessSerialNumber|ProcessSerialNumberPtr|ProcHandle|Ptr|ResType|ResTypePtr|ShortFixed|ShortFixedPtr|SignedByte|SInt16|SInt32|SInt64|SInt8|Size|StrFileName|StringHandle|StringPtr|TimeBase|TimeRecord|TimeScale|TimeValue|TimeValue64|UInt16|UInt32|UInt64|UInt8|UniChar|UniCharCount|UniCharCountPtr|UniCharPtr|UnicodeScalarValue|UniversalProcHandle|UniversalProcPtr|UnsignedFixed|UnsignedFixedPtr|UnsignedWide|UTF16Char|UTF32Char|UTF8Char)\b,
+    name: support.type.mac-classic.c++}
+- {include: '#block'}
+-   begin: |-
+        (?x)
+                    (?:  ^                                 # begin-of-line
+                      |
+                         (?: (?= \s )           (?<!else|new|return) (?<=\w)      #  or word + space before name
+                           | (?= \s*[A-Za-z_] ) (?<!&&)       (?<=[*&>])   #  or type modifier before name
+                         )
+                    )
+                    (\s*) (?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate|sizeof|alignof)\s*\()
+                    (
+                        (?: [~A-Za-z_]\w*+ | :: | <(\w+,?\s*)++> )++ |                  # actual name
+                        (?: (?<=operator) (?: [-*&<>=+!]+ | \(\) | \[\] ) )  # if it is a C++ operator
+                    )
+                     \s*(?=\()
+    beginCaptures:
+        '1': {name: punctuation.whitespace.function.leading.c++}
+        '3': {name: entity.name.function.c++}
+        '4': {name: punctuation.definition.parameters.c++}
+    end: (?<=\})|(?=#)|(;)
+    name: meta.function.c++
+    patterns:
+    - {include: '#comments'}
+    - {include: '#parens'}
+    - {match: \b(const|override|final|noexcept)\b, name: storage.modifier.c++}
+    - {include: '#block'}
+- {match: \b(friend|explicit|virtual)\b, name: storage.modifier.c++}
+- {match: '\b(private:|protected:|public:)', name: storage.modifier.c++}
+- {match: \b(catch|operator|try|throw|using)\b, name: keyword.control.c++}
+- {match: '\bdelete\b(\s*\[\])?|\bnew\b(?!])', name: keyword.control.c++}
+- {comment: common C++ instance var naming idiom -- fMemberName, match: '\b(f|m)[A-Z]\w*\b',
+    name: variable.other.readwrite.member.c++}
+- {match: \b(this)\b, name: variable.language.c++}
+- {match: '\btemplate(<[\s\w,<>]*>)?', name: storage.type.template.c++}
+- {match: \b(const_cast|dynamic_cast|reinterpret_cast|static_cast)\b\s*, name: keyword.operator.cast.c++}
+-   match: |-
+        (?x)(
+                        \b(?:and|and_eq|bitand|bitor|compl|not|not_eq|or|or_eq|typeid|xor|xor_eq)\b
+                    )
+    name: keyword.operator.c++
+- {match: \b(class|wchar_t)\b, name: storage.type.c++}
+- {match: \b(export|mutable|typename)\b, name: storage.modifier.c++}
+-   begin: |
+        (?x)
+                            (?:  ^                                 # begin-of-line
+                              |  (?: (?<!else|new|=) )             #  or word + space before name
+                            )
+                            ((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
+                             \s*(\()                           # start bracket or end-of-line
+    beginCaptures:
+        '1': {name: entity.name.function.c++}
+        '2': {name: punctuation.definition.parameters.c++}
+    end: \)
+    endCaptures:
+        '0': {name: punctuation.definition.parameters.c++}
+    name: meta.function.destructor.c++
+    patterns:
+    - {include: $base}
+-   begin: |
+        (?x)
+                            (?:  ^                                 # begin-of-line
+                              |  (?: (?<!else|new|=) )             #  or word + space before name
+                            )
+                            ((?:[A-Za-z_]\w*::)*+~[A-Za-z_]\w*) # actual name
+                             \s*(\()                           # terminating semi-colon
+    beginCaptures:
+        '1': {name: entity.name.function.c++}
+        '2': {name: punctuation.definition.parameters.c++}
+    end: \)
+    endCaptures:
+        '0': {name: punctuation.definition.parameters.c++}
+    name: meta.function.destructor.prototype.c++
+    patterns:
+    - {include: $base}
+repository:
+    access: {match: '\.[a-zA-Z_]\w*\b(?!\s*\()|\->[a-zA-Z_]\w*\b(?!\s*\()', name: variable.other.dot-access.c++}
+    angle_brackets:
+        begin: <
+        end: '>'
+        name: meta.angle-brackets.c++
+        patterns:
+        - {include: '#angle_brackets'}
+        - {include: $base}
+    block:
+        begin: \{
+        end: \}
+        name: meta.block.c++
+        patterns:
+        - {include: '#block_innards'}
+    block_innards:
+        patterns:
+        - {include: '#preprocessor-rule-enabled-block'}
+        - {include: '#preprocessor-rule-disabled-block'}
+        - {include: '#preprocessor-rule-other-block'}
+        - {include: '#operator'}
+        - {include: '#access'}
+        -   captures:
+                '1': {name: punctuation.whitespace.support.function.leading.c++}
+                '2': {name: support.function.C99.c++}
+            match: (\s*)\b(hypot(f|l)?|s(scanf|ystem|nprintf|ca(nf|lb(n(f|l)?|ln(f|l)?))|i(n(h(f|l)?|f|l)?|gn(al|bit))|tr(s(tr|pn)|nc(py|at|mp)|c(spn|hr|oll|py|at|mp)|to(imax|d|u(l(l)?|max)|k|f|l(d|l)?)|error|pbrk|ftime|len|rchr|xfrm)|printf|et(jmp|vbuf|locale|buf)|qrt(f|l)?|w(scanf|printf)|rand)|n(e(arbyint(f|l)?|xt(toward(f|l)?|after(f|l)?))|an(f|l)?)|c(s(in(h(f|l)?|f|l)?|qrt(f|l)?)|cos(h(f)?|f|l)?|imag(f|l)?|t(ime|an(h(f|l)?|f|l)?)|o(s(h(f|l)?|f|l)?|nj(f|l)?|pysign(f|l)?)|p(ow(f|l)?|roj(f|l)?)|e(il(f|l)?|xp(f|l)?)|l(o(ck|g(f|l)?)|earerr)|a(sin(h(f|l)?|f|l)?|cos(h(f|l)?|f|l)?|tan(h(f|l)?|f|l)?|lloc|rg(f|l)?|bs(f|l)?)|real(f|l)?|brt(f|l)?)|t(ime|o(upper|lower)|an(h(f|l)?|f|l)?|runc(f|l)?|gamma(f|l)?|mp(nam|file))|i(s(space|n(ormal|an)|cntrl|inf|digit|u(nordered|pper)|p(unct|rint)|finite|w(space|c(ntrl|type)|digit|upper|p(unct|rint)|lower|al(num|pha)|graph|xdigit|blank)|l(ower|ess(equal|greater)?)|al(num|pha)|gr(eater(equal)?|aph)|xdigit|blank)|logb(f|l)?|max(div|abs))|di(v|fftime)|_Exit|unget(c|wc)|p(ow(f|l)?|ut(s|c(har)?|wc(har)?)|error|rintf)|e(rf(c(f|l)?|f|l)?|x(it|p(2(f|l)?|f|l|m1(f|l)?)?))|v(s(scanf|nprintf|canf|printf|w(scanf|printf))|printf|f(scanf|printf|w(scanf|printf))|w(scanf|printf)|a_(start|copy|end|arg))|qsort|f(s(canf|e(tpos|ek))|close|tell|open|dim(f|l)?|p(classify|ut(s|c|w(s|c))|rintf)|e(holdexcept|set(e(nv|xceptflag)|round)|clearexcept|testexcept|of|updateenv|r(aiseexcept|ror)|get(e(nv|xceptflag)|round))|flush|w(scanf|ide|printf|rite)|loor(f|l)?|abs(f|l)?|get(s|c|pos|w(s|c))|re(open|e|ad|xp(f|l)?)|m(in(f|l)?|od(f|l)?|a(f|l|x(f|l)?)?))|l(d(iv|exp(f|l)?)|o(ngjmp|cal(time|econv)|g(1(p(f|l)?|0(f|l)?)|2(f|l)?|f|l|b(f|l)?)?)|abs|l(div|abs|r(int(f|l)?|ound(f|l)?))|r(int(f|l)?|ound(f|l)?)|gamma(f|l)?)|w(scanf|c(s(s(tr|pn)|nc(py|at|mp)|c(spn|hr|oll|py|at|mp)|to(imax|d|u(l(l)?|max)|k|f|l(d|l)?|mbs)|pbrk|ftime|len|r(chr|tombs)|xfrm)|to(b|mb)|rtomb)|printf|mem(set|c(hr|py|mp)|move))|a(s(sert|ctime|in(h(f|l)?|f|l)?)|cos(h(f|l)?|f|l)?|t(o(i|f|l(l)?)|exit|an(h(f|l)?|2(f|l)?|f|l)?)|b(s|ort))|g(et(s|c(har)?|env|wc(har)?)|mtime)|r(int(f|l)?|ound(f|l)?|e(name|alloc|wind|m(ove|quo(f|l)?|ainder(f|l)?))|a(nd|ise))|b(search|towc)|m(odf(f|l)?|em(set|c(hr|py|mp)|move)|ktime|alloc|b(s(init|towcs|rtowcs)|towc|len|r(towc|len))))\b
+        -   captures:
+                '1': {name: punctuation.whitespace.function-call.leading.c++}
+                '2': {name: entity.name.function.c++}
+                '3': {name: punctuation.definition.parameters.c++}
+            match: |-
+                (?x) (?: (?= \s )  (?:(?<=else|new|return) | (?<!\w)) (\s+))?
+                            (\b
+                                (?!(while|for|do|if|else|switch|catch|enumerate|return|r?iterate|sizeof|alignof)\s*\()(?:(?!NS)[A-Za-z_]\w*+\b | :: )++                  # actual name
+                            )
+                             \s*(\()
+            name: meta.function-call.c++
+        -   captures:
+                '1': {name: variable.other.c++}
+                '2': {name: punctuation.definition.parameters.c++}
+            match: |-
+                (?x)
+                                    (?x)
+                            (?:
+                                 (?: (?= \s )           (?<!else|new|return) (?<=\w)\s+      #  or word + space before name
+                                 )
+                            )
+                            (
+                                (?: [A-Za-z_]\w*+ | :: )++    |              # actual name
+                                (?: (?<=operator) (?: [-*&<>=+!]+ | \(\) | \[\] ) )?  # if it is a C++ operator
+                            )
+                             \s*(\()
+            name: meta.initialization.c++
+        - {include: '#block'}
+        - {include: $base}
+    comments:
+        patterns:
+        -   captures:
+                '1': {name: meta.toc-list.banner.block.c++}
+            match: ^/\* =(\s*.*?)\s*= \*/$\n?
+            name: comment.block.c++
+        -   begin: /\*
+            captures:
+                '0': {name: punctuation.definition.comment.c++}
+            end: \*/
+            name: comment.block.c++
+        - {match: \*/.*\n, name: invalid.illegal.stray-comment-end.c++}
+        -   captures:
+                '1': {name: meta.toc-list.banner.line.c++}
+            match: ^// =(\s*.*?)\s*=\s*$\n?
+            name: comment.line.banner.c++
+        -   begin: //
+            beginCaptures:
+                '0': {name: punctuation.definition.comment.c++}
+            end: $\n?
+            name: comment.line.double-slash.c++
+            patterns:
+            - {match: '(?>\\\s*\n)', name: punctuation.separator.continuation.c++}
+    constructor:
+        patterns:
+        -   begin: |
+                (?x)
+                                    (?:  ^\s*)                             # begin-of-line
+                                    ((?!while|for|do|if|else|switch|catch|enumerate|r?iterate|sizeof|alignof)[A-Za-z_][A-Za-z0-9_:]*) # actual name
+                                     \s*(\()                            # start bracket or end-of-line
+            beginCaptures:
+                '1': {name: entity.name.function.c++}
+                '2': {name: punctuation.definition.parameters.c++}
+            end: \)
+            endCaptures:
+                '0': {name: punctuation.definition.parameters.c++}
+            name: meta.function.constructor.c++
+            patterns:
+            - {include: $base}
+        -   begin: |
+                (?x)
+                                    (:)                            # begin-of-line
+                                    ((?=\s*[A-Za-z_][A-Za-z0-9_:]* # actual name
+                                     \s*(\()))                      # start bracket or end-of-line
+            beginCaptures:
+                '1': {name: punctuation.definition.parameters.c++}
+            end: (?=\{)
+            name: meta.function.constructor.initializer-list.c++
+            patterns:
+            - {include: $base}
+    disabled:
+        begin: ^\s*#\s*if(n?def)?\b.*$
+        comment: eat nested preprocessor if(def)s
+        end: ^\s*#\s*endif\b.*$
+        patterns:
+        - {include: '#disabled'}
+        - {include: '#pragma-mark'}
+    operator: {match: \b(sizeof|alignof)\b, name: keyword.operator.function.c++}
+    parens:
+        begin: \(
+        end: \)
+        name: meta.parens.c++
+        patterns:
+        - {include: $base}
+    pragma-mark:
+        captures:
+            '1': {name: meta.preprocessor.c++}
+            '2': {name: keyword.control.import.pragma.c++}
+            '3': {name: meta.toc-list.pragma-mark.c++}
+        match: ^\s*(#\s*(pragma\s+mark)\s+(.*))
+        name: meta.section
+    preprocessor-rule-disabled:
+        begin: ^\s*(#(if)\s+(0)\b).*
+        captures:
+            '1': {name: meta.preprocessor.c++}
+            '2': {name: keyword.control.import.if.c++}
+            '3': {name: constant.numeric.preprocessor.c++}
+        end: ^\s*(#\s*(endif)\b)
+        patterns:
+        -   begin: ^\s*(#\s*(else)\b)
+            captures:
+                '1': {name: meta.preprocessor.c++}
+                '2': {name: keyword.control.import.else.c++}
+            end: (?=^\s*#\s*endif\b.*$)
+            patterns:
+            - {include: $base}
+        -   begin: ''
+            end: (?=^\s*#\s*(else|endif)\b.*$)
+            name: comment.block.preprocessor.if-branch
+            patterns:
+            - {include: '#disabled'}
+            - {include: '#pragma-mark'}
+    preprocessor-rule-disabled-block:
+        begin: ^\s*(#(if)\s+(0)\b).*
+        captures:
+            '1': {name: meta.preprocessor.c++}
+            '2': {name: keyword.control.import.if.c++}
+            '3': {name: constant.numeric.preprocessor.c++}
+        end: ^\s*(#\s*(endif)\b)
+        patterns:
+        -   begin: ^\s*(#\s*(else)\b)
+            captures:
+                '1': {name: meta.preprocessor.c++}
+                '2': {name: keyword.control.import.else.c++}
+            end: (?=^\s*#\s*endif\b.*$)
+            patterns:
+            - {include: '#block_innards'}
+        -   begin: ''
+            end: (?=^\s*#\s*(else|endif)\b.*$)
+            name: comment.block.preprocessor.if-branch.in-block
+            patterns:
+            - {include: '#disabled'}
+            - {include: '#pragma-mark'}
+    preprocessor-rule-enabled:
+        begin: ^\s*(#(if)\s+(0*1)\b)
+        captures:
+            '1': {name: meta.preprocessor.c++}
+            '2': {name: keyword.control.import.if.c++}
+            '3': {name: constant.numeric.preprocessor.c++}
+        end: ^\s*(#\s*(endif)\b)
+        patterns:
+        -   begin: ^\s*(#\s*(else)\b).*
+            captures:
+                '1': {name: meta.preprocessor.c++}
+                '2': {name: keyword.control.import.else.c++}
+            contentName: comment.block.preprocessor.else-branch
+            end: (?=^\s*#\s*endif\b.*$)
+            patterns:
+            - {include: '#disabled'}
+            - {include: '#pragma-mark'}
+        -   begin: ''
+            end: (?=^\s*#\s*(else|endif)\b.*$)
+            patterns:
+            - {include: $base}
+    preprocessor-rule-enabled-block:
+        begin: ^\s*(#(if)\s+(0*1)\b)
+        captures:
+            '1': {name: meta.preprocessor.c++}
+            '2': {name: keyword.control.import.if.c++}
+            '3': {name: constant.numeric.preprocessor.c++}
+        end: ^\s*(#\s*(endif)\b)
+        patterns:
+        -   begin: ^\s*(#\s*(else)\b).*
+            captures:
+                '1': {name: meta.preprocessor.c++}
+                '2': {name: keyword.control.import.else.c++}
+            contentName: comment.block.preprocessor.else-branch.in-block
+            end: (?=^\s*#\s*endif\b.*$)
+            patterns:
+            - {include: '#disabled'}
+            - {include: '#pragma-mark'}
+        -   begin: ''
+            end: (?=^\s*#\s*(else|endif)\b.*$)
+            patterns:
+            - {include: '#block_innards'}
+    preprocessor-rule-other:
+        begin: ^\s*(#\s*(if(n?def)?)\b.*?(?:(?=(?://|/\*))|$))
+        captures:
+            '1': {name: meta.preprocessor.c++}
+            '2': {name: keyword.control.import.c++}
+        end: ^\s*(#\s*(endif)\b).*$
+        patterns:
+        - {include: $base}
+    preprocessor-rule-other-block:
+        begin: ^\s*(#\s*(if(n?def)?)\b.*?(?:(?=(?://|/\*))|$))
+        captures:
+            '1': {name: meta.preprocessor.c++}
+            '2': {name: keyword.control.import.c++}
+        end: ^\s*(#\s*(endif)\b).*$
+        patterns:
+        - {include: '#block_innards'}
+    special_block:
+        patterns:
+        -   captures:
+                '1': {name: keyword.control.namespace.c++}
+                '2': {name: entity.name.section.namespace.c++}
+            match: (?mx)\b(namespace)\s+((?:[a-zA-Z_][a-zA-Z0-9_:]*)+)?
+            name: meta.namespace-decl.c++
+        -   begin: \b(class|struct)\s+([_A-Za-z][_A-Za-z0-9]*\b)
+            beginCaptures:
+                '1': {name: storage.type.c++}
+                '2': {name: entity.name.type.c++}
+            end: (?<=\})|(?=(;|,|\(|\)|>|\[|\]))
+            name: meta.class-struct-block.c++
+            patterns:
+            - {include: '#angle_brackets'}
+            -   begin: (\{)
+                beginCaptures:
+                    '1': {name: punctuation.definition.scope.c++}
+                end: (\})(\s*\n)?
+                endCaptures:
+                    '1': {name: punctuation.definition.invalid.c++}
+                    '2': {name: invalid.illegal.you-forgot-semicolon.c++}
+                patterns:
+                - {include: '#special_block'}
+                - {include: '#constructor'}
+                - {include: $base}
+            - {include: $base}
+        -   begin: \b(extern)(?=\s*")
+            beginCaptures:
+                '1': {name: storage.modifier.c++}
+            end: (?<=\})|(?=\w)
+            name: meta.extern-block.c++
+            patterns:
+            -   begin: \{
+                end: \}
+                patterns:
+                - {include: '#special_block'}
+                - {include: $base}
+            - {include: $base}
+    string_escaped_char:
+        patterns:
+        - {match: '\\(\\|[abefnprtv''"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})',
+            name: constant.character.escape.c++}
+        - {match: \\., name: invalid.illegal.unknown-escape.c++}
+    string_placeholder:
+        patterns:
+        -   match: |
+                (?x)%
+                                            (\d+\$)?                             # field (argument #)
+                                            [#0\- +']*                           # flags
+                                            [,;:_]?                              # separator character (AltiVec)
+                                            ((-?\d+)|\*(-?\d+\$)?)?              # minimum field width
+                                            (\.((-?\d+)|\*(-?\d+\$)?)?)?         # precision
+                                            (hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier
+                                            [diouxXDOUeEfFgGaACcSspn%]           # conversion type
+            name: constant.other.placeholder.c++
+        - {match: '%', name: invalid.illegal.placeholder.c++}
+scopeName: source.c++
+uuid: 26251B18-6B1D-11D9-AFDB-000D93589AF6


### PR DESCRIPTION
There are a few minor changes in this pull request but the main one is a change to using a YAML file for syntax definition. This has resulted in quite large diffs even though the underlying regular expressions have not changed due to trivial formatting differences.

The YAML->PLIST converter I am using is the new SerializedDataConverter package found here:

https://github.com/facelessuser/SerializedDataConverter

I think YAML is much easier to read and edit than XML and it makes sense to make changes to it and let the machines deal with the raw .tmLanguage file.
