### PR TITLE
Added typedef declaration

### DIFF
--- a/C++11.tmLanguage
+++ b/C++11.tmLanguage
@@ -1476,6 +1476,25 @@
 					</array>
 				</dict>
 				<dict>
+					<key>match</key>
+					<string>^\s*(typedef)\s+.*\s+([_A-Za-z][_A-Za-z0-9]*);</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.c++</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.type.class.c++</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.typedef-declaration.c++</string>
+				</dict>
+				<dict>
 					<key>begin</key>
 					<string>\b(class|struct)\s+([_A-Za-z][_A-Za-z0-9]*\b)</string>
 					<key>beginCaptures</key>

--- a/C++11.tmLanguage
+++ b/C++11.tmLanguage
@@ -1477,7 +1477,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>^\s*(typedef)\s+.*\s+([_A-Za-z][_A-Za-z0-9]*);</string>
+					<string>\b(typedef)\s+.*\s+([_A-Za-z][_A-Za-z0-9]*);</string>
 					<key>captures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Like struct/classes. It will allow using 'go to declaration'.
It may be hard to parse smth like `typedef void (Class::*foo)(void * ptr, int (OtherClass::*)());`, but I think at least `typedef ... name;` will be good.
