### PR TITLE
Fix #17, highlight the inherited class and its inheritance type.

### DIFF
--- a/C++11.tmLanguage
+++ b/C++11.tmLanguage
@@ -1502,7 +1502,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>\b(class|struct)\s+([_A-Za-z][_A-Za-z0-9]*\b)</string>
+					<string>\b(class|struct)\s+([_A-Za-z][_A-Za-z0-9]*)(?:\s*:\s*(private|protected|public)?\s+([_A-Za-z][_A-Za-z0-9]*)(?:\s*,\s*(private|protected|public)?\s+([_A-Za-z][_A-Za-z0-9]*))*)?</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1511,6 +1511,26 @@
 							<string>storage.type.c++</string>
 						</dict>
 						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.type.class.c++</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.c++</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.type.class.c++</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.c++</string>
+						</dict>
+						<key>6</key>
 						<dict>
 							<key>name</key>
 							<string>entity.name.type.class.c++</string>

--- a/C++11.tmLanguage
+++ b/C++11.tmLanguage
@@ -146,7 +146,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b</string>
+			<string>\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+('[0-9]+)*\.?([0-9]+('[0-9]+)*)?)|(\.[0-9]+('[0-9]+)*))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b</string>
 			<key>name</key>
 			<string>constant.numeric.c++</string>
 		</dict>


### PR DESCRIPTION
After this PR:
![2015-10-20_14-04-34](https://cloud.githubusercontent.com/assets/6594915/10599334/b837766c-7733-11e5-92c8-cce3eb2d001f.png)

It looks like the regex ((SUBPATTERN)*) only capture the last occurrence so `protected C` is still not highlighted.
