### PR TITLE
User-defined number literals, class definition modifiers

### DIFF
--- a/C++11.tmLanguage
+++ b/C++11.tmLanguage
@@ -146,7 +146,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\b</string>
+			<string>\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)[A-Za-z_]?[A-Za-z0-9_]*\b</string>
 			<key>name</key>
 			<string>constant.numeric.c++</string>
 		</dict>
@@ -1525,6 +1525,12 @@
 						<dict>
 							<key>include</key>
 							<string>#angle_brackets</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\b(private|protected|public|final)\b</string>
+							<key>name</key>
+							<string>storage.modifier.c++</string>
 						</dict>
 						<dict>
 							<key>begin</key>


### PR DESCRIPTION
- As of C++11, integral and floating-point literals can be followed by a user-defined literal
- Class and Struct definitions can contain the final, private, protected, public keywords 
